### PR TITLE
remove color-eyre from build dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+### Removed
+- dependency on `color-eyre` in build.rs
 
-## [0.1.0] - 2020-09-15
+## [0.1.1] - 2020-09-15
 ### Changed
 - enabled the `parallel` feature of `cc` to enable parallel compilation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+
+## [0.1.2] - 2020-09-21
 ### Removed
 - dependency on `color-eyre` in build.rs
 
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `bindgen` to a non yanked version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ZcashFoundation/zcash_script/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ bindgen = "0.55"
 rustc-serialize = "0.3"
 hex = "0.4.2"
 lazy_static = "1.4.0"
-color-eyre = "0.5.0"
 
 [[package.metadata.release.pre-release-replacements]]
 file = "CHANGELOG.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_script"
-version = "0.1.2-rc.1"
+version = "0.1.2"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>", "Zcash Foundation <zebra@zfnd.org>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,13 +55,13 @@ blake2b_simd = "0.5.10"
 
 [build-dependencies]
 cc = { version = ">= 1.0.36, <= 1.0.41", features = ["parallel"] }
-color-eyre = "0.5.0"
 bindgen = "0.55"
 
 [dev-dependencies]
 rustc-serialize = "0.3"
 hex = "0.4.2"
 lazy_static = "1.4.0"
+color-eyre = "0.5.0"
 
 [[package.metadata.release.pre-release-replacements]]
 file = "CHANGELOG.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_script"
-version = "0.1.2-alpha.0"
+version = "0.1.2-rc.1"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>", "Zcash Foundation <zebra@zfnd.org>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_script"
-version = "0.1.2"
+version = "0.1.3-alpha.0"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>", "Zcash Foundation <zebra@zfnd.org>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
-#![doc(html_root_url = "https://docs.rs/zcash_script/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/zcash_script/0.1.2")]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
this fixes an issue in `zebra` where we cannot use release candidate builds for `color-eyre` because they end up being version incompatible with the dependency on `color-eyre` in `zcash_script`. I did not realize that build-dependencies were considered when doing dependency unification and I find this all a bit odd so I might be misunderstanding things but hopefully not, we shall see if this fix works soon...