### PR TITLE
bump bindgen back to 0.54 for compatibility with rocksdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+
+## [0.1.4] - 2020-11-17
 ### Changed
 - switched from bindgen `0.55` to bindgen `0.54` to avoid a dependency
   conflict with `rocksdb`
@@ -31,7 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `bindgen` to a non yanked version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+### Changed
+- switched from bindgen `0.55` to bindgen `0.54` to avoid a dependency
+  conflict with `rocksdb`
 
 ## [0.1.3] - 2020-10-09
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ blake2b_simd = "0.5.10"
 
 [build-dependencies]
 cc = { version = ">= 1.0.36, <= 1.0.41", features = ["parallel"] }
-bindgen = "0.55"
+bindgen = "0.54"
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_script"
-version = "0.1.4-alpha.0"
+version = "0.1.4"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>", "Zcash Foundation <zebra@zfnd.org>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_script"
-version = "0.1.4"
+version = "0.1.5-alpha.0"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>", "Zcash Foundation <zebra@zfnd.org>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
-#![doc(html_root_url = "https://docs.rs/zcash_script/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/zcash_script/0.1.4")]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
Prior to this PR, adding a `rocksdb` dependency to `zebra-state` causes a dependency resolver error in cargo, because we end up depending on two different versions of `clang-sys` which can only be linked in once per application.

This change decrements the bindgen version we use from `0.55` to the version used by `rocksdb`, `0.54`, which causes the dependency resolver to find a single version of `clang-sys` which works for both dependencies.