### PR TITLE
Relax cc dep, bump bindgen (Apple M1 support)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,10 @@ jobs:
       #   run: brew install llvm
       - name: install LLVM on Windows
         if: matrix.os == 'windows-latest'
-        run: choco install llvm -y
+        run: |
+          choco install llvm -y
+          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ libc="0.2"
 blake2b_simd = "0.5.10"
 
 [build-dependencies]
-cc = { version = ">= 1.0.36, <= 1.0.41", features = ["parallel"] }
-bindgen = "0.54"
+cc = { version = ">= 1.0.36", features = ["parallel"] }
+bindgen = "0.58"
 
 [dev-dependencies]
 rustc-serialize = "0.3"


### PR DESCRIPTION
- `bindgen` fix M1 issue in 0.58.0: https://github.com/rust-lang/rust-bindgen/blob/master/CHANGELOG.md#0580 (AArch64 bug)
- `cc` was pinned in https://github.com/ZcashFoundation/zcash_script/commit/6c5cc47f90634347f7119445fa368a068a21b120#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542 but `rust-secp256k1` do not restrict `cc` anymore: https://github.com/rust-bitcoin/rust-secp256k1/commit/fd8b3ff572354ecb30cf1c783d393fbb404a5a9c#diff-45481f3ec5a7270ec2be00f4ce78c833c29070204eb195bac332377b0d63299b Also [ring:0.16.17](https://crates.io/crates/ring/0.16.17/dependencies) (minimal version which support Apple M1) require `cc >= 1.0.62`.