### PR TITLE
Build the `secp256k1` C files separately

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -60,6 +60,7 @@ fn main() -> Result<()> {
         .flag_if_supported("-Wno-reorder")
         .flag_if_supported("-Wno-deprecated-copy")
         .flag_if_supported("-Wno-unused-parameter")
+        // when compiling using Microsoft Visual C++, ignore warnings about unused arguments
         .flag_if_supported("/wd4100")
         .define("HAVE_DECL_STRNLEN", "1")
         .define("__STDC_FORMAT_MACROS", None);

--- a/build.rs
+++ b/build.rs
@@ -61,7 +61,6 @@ fn main() -> Result<()> {
         false
     };
     let target = env::var("TARGET").expect("TARGET was not set");
-    let is_big_endian = env::var("CARGO_CFG_TARGET_ENDIAN").expect("No endian is set") == "big";
     let mut base_config = cc::Build::new();
 
     base_config
@@ -96,7 +95,7 @@ fn main() -> Result<()> {
             // The actual libsecp256k1 C code.
             .file("depend/zcash/src/secp256k1/src/secp256k1.c");
 
-        if is_big_endian {
+        if is_big_endian() {
             base_config.define("WORDS_BIGENDIAN", "1");
         }
 
@@ -141,4 +140,11 @@ fn main() -> Result<()> {
         .compile("libzcash_script.a");
 
     Ok(())
+}
+
+/// Checker whether the target architecture is big endian.
+fn is_big_endian() -> bool {
+    let endianess = env::var("CARGO_CFG_TARGET_ENDIAN").expect("No endian is set");
+
+    endianess == "big"
 }

--- a/build.rs
+++ b/build.rs
@@ -58,6 +58,8 @@ fn main() -> Result<()> {
         .flag_if_supported("-Wno-catch-value")
         .flag_if_supported("-Wno-reorder")
         .flag_if_supported("-Wno-deprecated-copy")
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("/wd4100")
         .define("HAVE_DECL_STRNLEN", "1")
         .define("__STDC_FORMAT_MACROS", None);
 
@@ -99,9 +101,9 @@ fn main() -> Result<()> {
 
     let tool = base_config.get_compiler();
     if tool.is_like_msvc() {
-        base_config.flag("/std:c++17").flag("/wd4100");
+        base_config.flag("/std:c++17");
     } else if tool.is_like_clang() || tool.is_like_gnu() {
-        base_config.flag("-std=c++17").flag("-Wno-unused-parameter");
+        base_config.flag("-std=c++17");
     }
 
     if target.contains("windows") {


### PR DESCRIPTION
Clang currently warns that building C files using C++ mode is deprecated. This happens because the `secp256k1` C files are built together with the C++ files. This will get worse in the future because when updating the `zcash` dependency, the C files will lead to compiler errors due to subtle language version differences.

This PR solves both issues by building the `secp245k1` C files separately from the other Zcash C++ files. The resulting `libsecp256k1.a` and `libzcash_script.a` binaries are then available to be linked into the final Rust binary.

The PR also includes a few refactors to make the `main` function more concise and easier to read and update.