### PR TITLE
Add legacy sigops counts to the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,41 @@
 
 Rust bindings to the ECC's `zcash_script` c++ library.
 
-### Updating `depend/zcash`
+### Cloning and checking out `depend/zcash`
 
-To pull in recent changes from the upstream repo run the following:
-
+Clone this repository using:
 ```console
-git subtree pull -P depend/zcash <repo> <branch> --squash
+git clone --recurse-submodules
 ```
 
-For example:
+Or if you've already cloned:
+```console
+git submodule update --init
+```
+
+To pull the latest version, use:
+```console
+git pull --recurse-submodules
+```
+
+### Updating `depend/zcash`
+
+If you need to change the submodule's base branch:
+```console
+git config -f .gitmodules submodule.depend/zcash.branch <branch-name>
+```
+
+To pull in recent changes from the upstream repo:
 
 ```console
-git subtree pull -P depend/zcash https://github.com/str4d/zcash.git zcash-script-precompute --squash
+git submodule update --remote
+```
+
+To use a specific commit:
+
+```console
+cd depend/zcash
+git checkout <commit-hash>
 ```
 
 ### Publishing New Releases

--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,7 @@ enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::GenerateBindings => write!(f, "unable to generate bindings"),
+            Error::GenerateBindings => write!(f, "unable to generate bindings: try running 'git submodule init' and 'git submodule update'"),
             Error::WriteBindings(source) => write!(f, "unable to write bindings: {}", source),
             Error::Env(source) => source.fmt(f),
         }


### PR DESCRIPTION
## Motivation

[Zebra](https://github.com/ZcashFoundation/zebra) needs to check the `MAX_BLOCK_SIGOPS` consensus rule.
See https://github.com/ZcashFoundation/zebra/issues/3015

## Solution

Add legacy sigops counts to the [zcash_script](https://github.com/ZcashFoundation/zcash_script) library API.
You can see the actual `zcashd` submodule changes at https://github.com/zcash/zcash/pull/5373

Also updates the `zcash_script` README for git submodules.

### Dependency Stability

I tagged the `zcash_script` commit that Zebra depends on as:
https://github.com/ZcashFoundation/zcash_script/releases/tag/v0.1.6-alpha.1-zebra-v1.0.0-beta.0

I tagged the `zcashd` commit in the submodule as:
https://github.com/ZcashFoundation/zcashd/releases/tag/v4.5.1-1-zcash-script-zebra-v1.0.0-beta.0

These tags will make sure we don't accidentally delete the commits we're depending on.