### PR TITLE
Revert zcashd Orchard module structure changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,24 @@ replace="<!-- next-url -->\n[Unreleased]: https://github.com/ZcashFoundation/{{c
 exactly=1
 
 [patch.crates-io]
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "b7bd6246122a6e9ace8edb51553fbf5228906cbb" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "2c8241f25b943aa05203eacf9905db117c69bd29" }
+# Copied from Zebra after PR #3057
+
+# TODO: replace with upstream orchard when these changes are merged
+# https://github.com/ZcashFoundation/zebra/issues/3056
+orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
+
+# TODO: remove these after a new librustzcash release.
+
+# These are librustzcash git requirements specified in its workspace Cargo.toml,
+# that we must replicate here
+incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "b7bd6246122a6e9ace8edb51553fbf5228906cbb" }
+# Replaced by the ZcashFoundation fork above
+#orchard = { git = "https://github.com/zcash/orchard.git", rev = "2c8241f25b943aa05203eacf9905db117c69bd29" }
+
+# These are librustzcash file requirements specified in its workspace Cargo.toml,
+# that we must replace with git requirements
 zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
+
+# These patches are not strictly required,
+# but they help avoid duplicate dependencies
 zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ include = [
     "/.gitignore",
     "/.gitmodules",
     "Cargo.toml",
-    "Cargo.toml.orig",
     "/LICENSE",
     "/README.md",
     "build.rs",

--- a/src/orchard_ffi.rs
+++ b/src/orchard_ffi.rs
@@ -1,1 +1,1 @@
-include!("../depend/zcash/src/rust/src/orchard_ffi/mod.rs");
+include!("../depend/zcash/src/rust/src/orchard_ffi.rs");


### PR DESCRIPTION
This PR reverts the Orchard module structure changes from #22.
It is based on https://github.com/zcash/zcash/pull/5373

We should update it and merge as part of https://github.com/ZcashFoundation/zebra/issues/2982

Closes #26.