### PR TITLE
Update zcash to new V5 API; add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,25 @@ jobs:
           echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - uses: actions-rs/toolchain@v1
+        if: matrix.os == 'windows-latest'
+        with:
+          target: x86_64-pc-windows-gnu
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: actions-rs/toolchain@v1
+        if: matrix.os != 'windows-latest'
         with:
           toolchain: stable
           profile: minimal
           override: true
       - uses: actions-rs/cargo@v1
+        if: matrix.os == 'windows-latest'
+        with:
+          command: test
+          args: --target x86_64-pc-windows-gnu
+      - uses: actions-rs/cargo@v1
+        if: matrix.os != 'windows-latest'
         with:
           command: test
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "depend/zcash"]
 	path = depend/zcash
-	url = https://github.com/ZcashFoundation/zcashd.git
+	url = https://github.com/zcash/zcash.git
 	branch = nu5-consensus

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "depend/zcash"]
 	path = depend/zcash
 	url = https://github.com/zcash/zcash.git
-	branch = nu5-consensus
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "depend/zcash"]
 	path = depend/zcash
 	url = https://github.com/ZcashFoundation/zcashd.git
+	branch = zcash_script_v5_api

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "depend/zcash"]
 	path = depend/zcash
 	url = https://github.com/ZcashFoundation/zcashd.git
-	branch = zcash_script_v5_api
+	branch = nu5-consensus

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,11 +53,9 @@ external-secp = []
 
 [dependencies]
 blake2b_simd = "1"
-halo2 = "0.1.0-beta.1"
-incrementalmerkletree = "0.2"
 libc = "0.2"
 memuse = "0.2"
-orchard = "=0.1.0-beta.1"
+orchard = "=0.1.0-beta.2"
 rand_core = "0.6"
 tracing = "0.1"
 zcash_encoding = "0.0"
@@ -110,8 +108,8 @@ exactly=1
 
 [patch.crates-io]
 # From zcashd
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "ff243b4f0055d89d3abb526e234688a09c3d8cb7" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "ff243b4f0055d89d3abb526e234688a09c3d8cb7" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "ff243b4f0055d89d3abb526e234688a09c3d8cb7" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }
 # From zcash_primitives
 hdwallet = { git = "https://github.com/nuttycom/hdwallet", rev = "576683b9f2865f1118c309017ff36e01f84420c9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ external-secp = []
 blake2b_simd = "1"
 libc = "0.2"
 memuse = "0.2"
-orchard = "=0.1.0-beta.2"
+orchard = "=0.1.0-beta.3"
 rand_core = "0.6"
 tracing = "0.1"
 zcash_encoding = "0.0"
@@ -108,8 +108,7 @@ exactly=1
 
 [patch.crates-io]
 # From zcashd
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "9c1ed86c5aa8ae3b6d6dcc1478f2d6ba1264488f" }
-# From zcash_primitives
-hdwallet = { git = "https://github.com/nuttycom/hdwallet", rev = "576683b9f2865f1118c309017ff36e01f84420c9" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "43c18d000fcbe45363b2d53585d5102841eff99e" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "43c18d000fcbe45363b2d53585d5102841eff99e" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "43c18d000fcbe45363b2d53585d5102841eff99e" }
+hdwallet = { git = "https://github.com/nuttycom/hdwallet", rev = "9b4c1bdbe0517e3a7a8f285d6048a37d472ba3bc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,16 +52,17 @@ path = "src/lib.rs"
 external-secp = []
 
 [dependencies]
-blake2b_simd = "0.5.10"
+blake2b_simd = "1"
 halo2 = "0.1.0-beta.1"
-incrementalmerkletree = "0.1"
+incrementalmerkletree = "0.2"
 libc = "0.2"
 memuse = "0.2"
-orchard = "0.0"
+orchard = "=0.1.0-beta.1"
 rand_core = "0.6"
 tracing = "0.1"
-zcash_note_encryption = "0.0"
-zcash_primitives = "0.5"
+zcash_encoding = "0.0"
+zcash_note_encryption = "0.1"
+zcash_primitives = { version = "0.5", features = ["transparent-inputs"] }
 
 [build-dependencies]
 cc = { version = ">= 1.0.36", features = ["parallel"] }
@@ -108,7 +109,9 @@ replace="<!-- next-url -->\n[Unreleased]: https://github.com/ZcashFoundation/{{c
 exactly=1
 
 [patch.crates-io]
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "b7bd6246122a6e9ace8edb51553fbf5228906cbb" }
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "2c8241f25b943aa05203eacf9905db117c69bd29" }
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
+# From zcashd
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "ff243b4f0055d89d3abb526e234688a09c3d8cb7" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "ff243b4f0055d89d3abb526e234688a09c3d8cb7" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "ff243b4f0055d89d3abb526e234688a09c3d8cb7" }
+# From zcash_primitives
+hdwallet = { git = "https://github.com/nuttycom/hdwallet", rev = "576683b9f2865f1118c309017ff36e01f84420c9" }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
 
 Rust bindings to the ECC's `zcash_script` c++ library.
 
+`zcash_script` links to `librustzcash`, which is written in Rust. Therefore,
+when updating `zcash_script`, we need to make sure that
+
 ### Cloning and checking out `depend/zcash`
 
 Clone this repository using:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,24 @@
 [docs-badge]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-url]: https://docs.rs/zcash_script
 
-Rust bindings to the ECC's `zcash_script` c++ library.
+Rust bindings to the ECC's `zcash_script` C++ library.
 
-`zcash_script` links to `librustzcash`, which is written in Rust. Therefore,
-when updating `zcash_script`, we need to make sure that
+### Developing
+
+This crate works by manually including the `zcash_script` .h and .cpp files,
+using `bindgen` to generate Rust bindings, and compiling everything together
+into a single library. Due to the way the `zcash_script` is written we unfortunately need
+to include a lot of other stuff e.g. the orchard library.
+
+Note that `zcash_script` (the C++ library/folder inside `zcash`) uses some Rust
+FFI functions from `zcash`; and it also links to `librustzcash` which is written in Rust.
+Therefore, when updating `zcash_script` (this crate), we need to make sure that shared dependencies
+between all of those are the same versions (and are patched to the same revisions, if applicable).
+To do that, check for versions in:
+
+- `zcash/Cargo.toml` in the revision pointed to by this crate (also check for patches)
+- `librustzcash/Cargo.toml` in the revision pointed to by `zcash` (also check for patches)
+- `librustzcash/<crate>/Cargo.toml` in the revision pointed to by `zcash`
 
 ### Cloning and checking out `depend/zcash`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,20 @@ mod tests {
         pub static ref SCRIPT_TX: Vec<u8> = <Vec<u8>>::from_hex("0400008085202f8901fcaf44919d4a17f6181a02a7ebe0420be6f7dad1ef86755b81d5a9567456653c010000006a473044022035224ed7276e61affd53315eca059c92876bc2df61d84277cafd7af61d4dbf4002203ed72ea497a9f6b38eb29df08e830d99e32377edb8a574b8a289024f0241d7c40121031f54b095eae066d96b2557c1f99e40e967978a5fd117465dbec0986ca74201a6feffffff020050d6dc0100000017a9141b8a9bda4b62cd0d0582b55455d0778c86f8628f870d03c812030000001976a914e4ff5512ffafe9287992a1cd177ca6e408e0300388ac62070d0095070d000000000000000000000000").expect("Block bytes are in valid hex representation");
     }
 
+    /// Manually encode all previous outputs for a single output.
+    fn encode_all_prev_outputs(amount: i64, script_pub_key: &[u8]) -> (Vec<u8>, *const u8) {
+        // Number of transactions (CompactSize)
+        let mut all_prev_outputs = vec![1];
+        // Amount as 8 little-endian bytes
+        all_prev_outputs.extend(amount.to_le_bytes().iter().cloned());
+        // Length of the pub key script (CompactSize)
+        all_prev_outputs.push(script_pub_key.len() as u8);
+        // Pub key script
+        all_prev_outputs.extend(script_pub_key.iter().cloned());
+        let all_prev_outputs_ptr = all_prev_outputs.as_ptr();
+        (all_prev_outputs, all_prev_outputs_ptr)
+    }
+
     pub fn verify_script(
         script_pub_key: &[u8],
         amount: i64,
@@ -44,6 +58,28 @@ mod tests {
                 amount,
                 tx_to_ptr,
                 tx_to_len as u32,
+                nIn,
+                flags,
+                consensus_branch_id,
+                &mut err,
+            )
+        };
+
+        if ret != 1 {
+            return Err(err);
+        }
+
+        // Also test with the V5 API
+
+        let (all_prev_outputs, all_prev_outputs_ptr) =
+            encode_all_prev_outputs(amount, script_pub_key);
+
+        let ret = unsafe {
+            super::zcash_script_verify_v5(
+                tx_to_ptr,
+                tx_to_len as u32,
+                all_prev_outputs_ptr,
+                all_prev_outputs.len() as _,
                 nIn,
                 flags,
                 consensus_branch_id,
@@ -74,6 +110,40 @@ mod tests {
 
         let precomputed =
             unsafe { super::zcash_script_new_precomputed_tx(tx_to_ptr, tx_to_len as _, &mut err) };
+
+        let ret = unsafe {
+            super::zcash_script_verify_precomputed(
+                precomputed,
+                nIn,
+                script_ptr,
+                script_len as _,
+                amount,
+                flags,
+                consensus_branch_id,
+                &mut err,
+            )
+        };
+
+        unsafe { super::zcash_script_free_precomputed_tx(precomputed) };
+
+        if ret != 1 {
+            return Err(err);
+        }
+
+        // Also test with the V5 API
+
+        let (all_prev_outputs, all_prev_outputs_ptr) =
+            encode_all_prev_outputs(amount, script_pub_key);
+
+        let precomputed = unsafe {
+            super::zcash_script_new_precomputed_tx_v5(
+                tx_to_ptr,
+                tx_to_len as _,
+                all_prev_outputs_ptr,
+                all_prev_outputs.len() as _,
+                &mut err,
+            )
+        };
 
         let ret = unsafe {
             super::zcash_script_verify_precomputed(

--- a/src/orchard_ffi.rs
+++ b/src/orchard_ffi.rs
@@ -1,1 +1,1 @@
-include!("../depend/zcash/src/rust/src/orchard_ffi/mod.rs");
+include!("../depend/zcash/src/rust/src/orchard_ffi.rs");


### PR DESCRIPTION
Expose the new V5 `zcash_script` functions, which implement ZIP-244 changes, see https://github.com/zcash/zcash/pull/5607

This points to that PR (it must be updated after it's merged, so it's a draft PR for now) and add tests.