### PR TITLE
change: update dependencies for NU5 mainnet (matching zcashd 5.0.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,12 +55,12 @@ external-secp = []
 blake2b_simd = "1"
 libc = "0.2"
 memuse = "0.2"
-orchard = "=0.1.0-beta.3"
+orchard = "0.1"
 rand_core = "0.6"
 tracing = "0.1"
-zcash_encoding = "0.0"
+zcash_encoding = "0.1"
 zcash_note_encryption = "0.1"
-zcash_primitives = { version = "0.5", features = ["transparent-inputs"] }
+zcash_primitives = { version = "0.6", features = ["transparent-inputs"] }
 
 [build-dependencies]
 cc = { version = ">= 1.0.36", features = ["parallel"] }
@@ -105,10 +105,3 @@ file="CHANGELOG.md"
 search="<!-- next-url -->"
 replace="<!-- next-url -->\n[Unreleased]: https://github.com/ZcashFoundation/{{crate_name}}/compare/{{tag_name}}...HEAD"
 exactly=1
-
-[patch.crates-io]
-# From zcashd
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "43c18d000fcbe45363b2d53585d5102841eff99e" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "43c18d000fcbe45363b2d53585d5102841eff99e" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "43c18d000fcbe45363b2d53585d5102841eff99e" }
-hdwallet = { git = "https://github.com/nuttycom/hdwallet", rev = "9b4c1bdbe0517e3a7a8f285d6048a37d472ba3bc" }


### PR DESCRIPTION
We must update dependencies to match zcashd 5.0.0 for the NU5 mainnet release.

Part of https://github.com/ZcashFoundation/zebra/issues/3414