### PR TITLE
change(doc): update CHANGELOG for 0.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 
-## [Unreleased] - ReleaseDate
+## [0.1.6] - 2022-05-16
+
+### Changed
+- Exposed precomputation API
+- Updated `depend/zcash` to version 5.0.0 which includes API for V5 transactions
 
 ## [0.1.5] - 2020-12-09
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_script"
-version = "0.1.6-alpha.0"
+version = "0.1.6"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>", "Zcash Foundation <zebra@zfnd.org>"]
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
It has been ages since a proper release and it would nice to minimize git dependencies in the next release of Zebra (beta.10)