### PR TITLE
Activate dependabot on zcash_script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: '/'
+    schedule:
+      interval: daily
+      timezone: America/New_York
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+      timezone: America/New_York
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This helps us do dependency updates whenever we update the crate for other reasons.