### PR TITLE
Check for duplicate dependencies in CI

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -46,4 +46,4 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}
-          args: --workspace ${{ matrix.features }}
+          arguments: --workspace ${{ matrix.features }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,49 @@
+name: Check Dependencies
+
+# Ensures that only one workflow task will run at a time. Previous checks, if
+# already in process, will get cancelled. Only the latest commit will be allowed
+# to run, cancelling any workflows in between.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUST_LOG: info
+  RUST_BACKTRACE: full
+  RUST_LIB_BACKTRACE: full
+  COLORBT_SHOW_HIDDEN: '1'
+
+jobs:
+  cargo-deny:
+    name: Check deny.toml ${{ matrix.checks }} ${{ matrix.features }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - bans
+          - sources
+        features: ['', '--all-features', '--no-default-features']
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          persist-credentials: false
+
+      # this check also runs with optional features off
+      # so we expect some warnings about "skip tree root was not found"
+      - name: Check ${{ matrix.checks }} with features ${{ matrix.features }}
+        uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check ${{ matrix.checks }}
+          args: --workspace ${{ matrix.features }}


### PR DESCRIPTION
We can't use dependabot without checking dependency upgrades for duplicate dependencies.

I have already updated the branch protection rules to include these checks.