### PR TITLE
Allow clippy lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,4 +154,5 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          # TODO: remove the allowed lint when zcashd fiexes the code in zcash/src/rust/src/wallet.rs:540:14
+          args: -- -D warnings -A clippy::unwrap_or_default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,5 +154,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          # TODO: remove the allowed lint when zcashd fiexes the code in zcash/src/rust/src/wallet.rs:540:14
-          args: -- -D warnings -A clippy::unwrap_or_default
+          args: -- -D warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![allow(non_snake_case)]
 #![allow(unsafe_code)]
 #![allow(unused_imports)]
+#![allow(clippy::unwrap_or_default)]
 
 // Use the generated C++ bindings
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
In the last clippy version it seems there is a new lint or an update of it `unwrap_or_default`.

Code from zcashd will trigger the lint will will make the CI fail: https://github.com/zcash/zcash/blob/v5.7.0/src/rust/src/wallet.rs#L540

This pull request will allow the lint until it is fixed.