### PR TITLE
Create the v0.1.14 release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
-## [0.1.13] - 2023-07-05
+## [0.1.14] - 2023-10-18
+
+### Changed
+- Update `depend/zcash` to version 5.7.0 which includes updated dependencies
+- Update other dependencies to match Zebra
+- Update the `build.rs` to handle subdirs
 
 ## [0.1.13] - 2023-06-29
 
@@ -89,7 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `bindgen` to a non yanked version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.13...HEAD
+[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.14...HEAD
+[0.1.14]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.12...v0.1.13
 [0.1.12]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.10...v0.1.11


### PR DESCRIPTION
This PR updates the changelog for the release.

But when i run the command at step 2 in the README instructions i got the following, please note the warnings at the end:

```
oxarbitrage@oxarbitrage-Lenovo-ideapad-320S-14IKB:~/zebra/zcash_script_v0.1.14/zcash_script$ cargo release patch
   Upgrading zcash_script from 0.1.13 to 0.1.14
   Replacing in CHANGELOG.md
--- CHANGELOG.md	original
+++ CHANGELOG.md	replaced
@@ -9,0 +10,2 @@
+
+## [0.1.14] - 2023-10-18
@@ -97,0 +100 @@
+[0.1.14]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.14...v0.1.14

   Replacing in src/lib.rs
--- src/lib.rs	original
+++ src/lib.rs	replaced
@@ -4 +4 @@
-#![doc(html_root_url = "https://docs.rs/zcash_script/0.1.13")]
+#![doc(html_root_url = "https://docs.rs/zcash_script/0.1.14")]

  Publishing zcash_script
    Updating crates.io index
   Packaging zcash_script v0.1.13 (/home/oxarbitrage/zebra/zcash_script_v0.1.14/zcash_script)
   Verifying zcash_script v0.1.13 (/home/oxarbitrage/zebra/zcash_script_v0.1.14/zcash_script)
    Updating crates.io index
   Compiling libc v0.2.149
   Compiling cfg-if v1.0.0
   Compiling proc-macro2 v1.0.69
   Compiling unicode-ident v1.0.12
   Compiling version_check v0.9.4
   Compiling typenum v1.17.0
   Compiling subtle v2.4.1
   Compiling generic-array v0.14.7
   Compiling autocfg v1.1.0
   Compiling quote v1.0.33
   Compiling getrandom v0.2.10
   Compiling syn v2.0.38
   Compiling rand_core v0.6.4
   Compiling jobserver v0.1.27
   Compiling radium v0.7.0
   Compiling cc v1.0.83
   Compiling nonempty v0.7.0
   Compiling tap v1.0.1
   Compiling wyz v0.5.1
   Compiling crypto-common v0.1.6
   Compiling funty v2.0.0
   Compiling arrayref v0.3.7
   Compiling crossbeam-utils v0.8.16
   Compiling either v1.9.0
   Compiling bitvec v1.0.1
   Compiling constant_time_eq v0.3.0
   Compiling arrayvec v0.7.4
   Compiling memuse v0.2.1
   Compiling memoffset v0.9.0
   Compiling crossbeam-epoch v0.9.15
   Compiling spin v0.5.2
   Compiling cpufeatures v0.2.9
   Compiling blake2b_simd v1.0.2
   Compiling scopeguard v1.2.0
   Compiling ppv-lite86 v0.2.17
   Compiling once_cell v1.18.0
   Compiling byteorder v1.5.0
   Compiling rand_chacha v0.3.1
   Compiling ff v0.13.0
   Compiling group v0.13.0
   Compiling lazy_static v1.4.0
   Compiling inout v0.1.3
   Compiling block-buffer v0.10.4
   Compiling rayon-core v1.12.0
   Compiling digest v0.10.7
   Compiling crossbeam-deque v0.8.3
   Compiling rand v0.8.5
   Compiling static_assertions v1.1.0
   Compiling pairing v0.23.0
   Compiling num-traits v0.2.17
   Compiling thiserror v1.0.49
   Compiling pasta_curves v0.5.1
   Compiling rayon v1.8.0
   Compiling num-integer v0.1.45
   Compiling crunchy v0.2.2
   Compiling zeroize_derive v1.4.2
   Compiling thiserror-impl v1.0.49
   Compiling glob v0.3.1
   Compiling serde v1.0.189
   Compiling zeroize v1.6.0
   Compiling cipher v0.4.4
   Compiling hex v0.4.3
   Compiling clang-sys v1.6.1
   Compiling serde_derive v1.0.189
   Compiling tracing-attributes v0.1.27
   Compiling bls12_381 v0.8.0
   Compiling tracing-core v0.1.32
   Compiling secp256k1-sys v0.8.1
   Compiling universal-hash v0.5.1
   Compiling num-bigint v0.4.4
   Compiling opaque-debug v0.3.0
   Compiling prettyplease v0.2.15
   Compiling libm v0.2.8
   Compiling pin-project-lite v0.2.13
   Compiling rustix v0.38.19
   Compiling tracing v0.1.39
   Compiling poly1305 v0.8.0
   Compiling jubjub v0.10.0
   Compiling chacha20 v0.9.1
   Compiling maybe-rayon v0.1.1
   Compiling sha2 v0.10.8
   Compiling ring v0.16.20
   Compiling link-cplusplus v1.0.9
   Compiling aead v0.5.2
   Compiling log v0.4.20
   Compiling halo2_legacy_pdqsort v0.1.0
   Compiling home v0.5.5
   Compiling regex-syntax v0.8.2
   Compiling base64ct v1.0.1
   Compiling linux-raw-sys v0.4.10
   Compiling minimal-lexical v0.2.1
   Compiling bitflags v2.4.1
   Compiling tinyvec_macros v0.1.1
   Compiling memchr v2.6.4
   Compiling tinyvec v1.6.0
   Compiling nom v7.1.3
   Compiling reddsa v0.5.1
   Compiling regex-automata v0.4.3
   Compiling password-hash v0.3.2
   Compiling halo2_proofs v0.3.0
   Compiling chacha20poly1305 v0.10.1
   Compiling uint v0.9.5
   Compiling cbc v0.1.2
   Compiling incrementalmerkletree v0.5.0
   Compiling libloading v0.7.4
   Compiling bindgen v0.68.1
   Compiling cxxbridge-flags v1.0.107
   Compiling unicode-width v0.1.11
   Compiling untrusted v0.7.1
   Compiling termcolor v1.3.0
   Compiling syn v1.0.109
   Compiling codespan-reporting v0.11.1
   Compiling cxx v1.0.107
   Compiling halo2_gadgets v0.3.0
   Compiling fpe v0.6.1
   Compiling regex v1.10.2
   Compiling zcash_note_encryption v0.4.0
   Compiling pbkdf2 v0.10.1
   Compiling cexpr v0.6.0
   Compiling which v4.4.2
   Compiling unicode-normalization v0.1.22
   Compiling bs58 v0.5.0
   Compiling aes v0.8.3
   Compiling hmac v0.12.1
   Compiling zcash_encoding v0.2.0
   Compiling f4jumble v0.1.0
   Compiling blake2s_simd v1.0.2
   Compiling ahash v0.8.3
   Compiling lazycell v1.3.0
   Compiling shlex v1.2.0
   Compiling bech32 v0.9.1
   Compiling peeking_take_while v0.1.2
   Compiling rustc-hash v1.1.0
   Compiling zcash_address v0.3.0
   Compiling bip0039 v0.10.1
   Compiling orchard v0.6.0
   Compiling cxx-gen v0.7.109
   Compiling ripemd v0.1.3
   Compiling equihash v0.2.0
   Compiling crossbeam-channel v0.5.8
   Compiling num_cpus v1.16.0
   Compiling bellman v0.14.0
   Compiling redjubjub v0.7.0
   Compiling cxxbridge-macro v1.0.107
   Compiling zcash_script v0.1.13 (/home/oxarbitrage/zebra/zcash_script_v0.1.14/zcash_script/target/package/zcash_script-0.1.13)
   Compiling metrics-macros v0.7.0
   Compiling known-folders v1.0.1
   Compiling xdg v2.5.2
   Compiling metrics v0.21.1
   Compiling bridgetree v0.4.0
   Compiling secp256k1 v0.26.0
   Compiling hdwallet v0.4.1
   Compiling zcash_primitives v0.13.0-rc.1
   Compiling zcash_proofs v0.13.0-rc.1
    Finished dev [unoptimized + debuginfo] target(s) in 1m 37s
    Packaged 1078 files, 15.4MiB (5.3MiB compressed)
   Uploading zcash_script v0.1.13 (/home/oxarbitrage/zebra/zcash_script_v0.1.14/zcash_script)
warning: aborting upload due to dry run
     Pushing Pushing v0.1.14 to origin
warning: aborting release due to dry run; re-run with `--execute`
oxarbitrage@oxarbitrage-Lenovo-ideapad-320S-14IKB:~/zebra/zcash_script_v0.1.14/zcash_script$ 
```

Nothing changes and the bumps were not done. Any ideas ? Maybe @conradoplg ?