### PR TITLE
Create the v0.1.14 release - 2nd attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
-## [0.1.13] - 2023-07-05
+## [0.1.14] - 2023-10-18
+
+### Changed
+- Update `depend/zcash` to version 5.7.0 which includes updated dependencies
+- Update other dependencies to match Zebra
+- Update the `build.rs` to handle subdirs
 
 ## [0.1.13] - 2023-06-29
 
@@ -89,7 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `bindgen` to a non yanked version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.13...HEAD
+[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.14...HEAD
+[0.1.14]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.12...v0.1.13
 [0.1.12]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.10...v0.1.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.14] - 2023-10-18
 
+## [0.1.14] - 2023-10-18
+
 ### Changed
 - Update `depend/zcash` to version 5.7.0 which includes updated dependencies
 - Update other dependencies to match Zebra
@@ -95,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-url -->
 [Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.14...HEAD
+[0.1.14]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.14...v0.1.14
 [0.1.14]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.12...v0.1.13
 [0.1.12]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.11...v0.1.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
-## [0.1.14] - 2023-10-18
 
 ## [0.1.14] - 2023-10-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "bellman",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_script"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>", "Zcash Foundation <zebra@zfnd.org>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Rust bindings for Zcash transparent scripts.
 
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
-#![doc(html_root_url = "https://docs.rs/zcash_script/0.1.13")]
+#![doc(html_root_url = "https://docs.rs/zcash_script/0.1.14")]
 #![allow(missing_docs)]
 #![allow(clippy::needless_lifetimes)]
 #![allow(non_upper_case_globals)]


### PR DESCRIPTION
This replaces https://github.com/ZcashFoundation/zcash_script/pull/109 but with the versions bumped.

In https://github.com/ZcashFoundation/zcash_script/pull/109 i created a branch with the same name as the tag so i can't push anymore so created the new `v0.1.14_2` branch here.

Then i think we will have to manually tag here in github as the new version was upgraded in crates.io (https://crates.io/crates/zcash_script) but the tag was not created in github:

```
oxarbitrage@oxarbitrage-Lenovo-ideapad-320S-14IKB:~/zebra/zcash_script_v0.1.14/2/zcash_script$ cargo release --execute patch
Release zcash_script 0.1.14? [y/N] 
y
   Upgrading zcash_script from 0.1.13 to 0.1.14
[v0.1.14 392123b] chore: Release zcash_script version 0.1.14
 4 files changed, 6 insertions(+), 3 deletions(-)
  Publishing zcash_script
    Updating crates.io index

...

note: Waiting for `zcash_script v0.1.14` to be available at registry `crates-io`.
You may press ctrl-c to skip waiting; the crate should be available shortly.
   Published zcash_script v0.1.14 at registry `crates-io`
error: object is no commit object; class=Invalid (3)
oxarbitrage@oxarbitrage-Lenovo-ideapad-320S-14IKB:~/zebra/zcash_script_v0.1.14/2/zcash_script$ 
```