### PR TITLE
Bump the release v0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.15] - 2024-04-19
 
-## [0.1.15] - 2024-04-11
-
 ### Changed
 - Update `depend/zcash` to version 5.8.0 which includes updated dependencies
 - Update other dependencies to match Zebra
@@ -104,7 +102,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-url -->
 [Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.15...HEAD
-[0.1.15]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.15...v0.1.15
 [0.1.15]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.12...v0.1.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [0.1.15] - 2024-04-19
+
 ## [0.1.15] - 2024-04-11
 
 ### Changed
@@ -102,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-url -->
 [Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.15...HEAD
+[0.1.15]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.15...v0.1.15
 [0.1.15]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.12...v0.1.13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "bellman",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_script"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>", "Zcash Foundation <zebra@zfnd.org>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Rust bindings for Zcash transparent scripts.
 
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
-#![doc(html_root_url = "https://docs.rs/zcash_script/0.1.14")]
+#![doc(html_root_url = "https://docs.rs/zcash_script/0.1.15")]
 #![allow(missing_docs)]
 #![allow(clippy::needless_lifetimes)]
 #![allow(non_upper_case_globals)]


### PR DESCRIPTION
Release is [published to crates.io](https://crates.io/crates/zcash_script) but the versions need to be bumped in the github. `cargo release` fails to publish to master directly so i had to make this PR with the results. 