### PR TITLE
Add a basic rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,10 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -32,46 +24,57 @@ jobs:
     name: Package
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        rust:
-          - stable
+        toolchain:
+          - rust-toolchain.toml
           - nightly
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
       - uses: actions-rs/cargo@v1
+        if: matrix.toolchain == 'rust-toolchain.toml'
         with:
           command: package
+      - run: rustup install ${{ matrix.toolchain }}
+        if: matrix.toolchain != 'rust-toolchain.toml'
+      - uses: actions-rs/cargo@v1
+        if: matrix.toolchain != 'rust-toolchain.toml'
+        with:
+          command: package
+          toolchain: ${{ matrix.toolchain }}
 
   test-versions:
     name: Test Suite
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        rust:
-          - stable
+        toolchain:
+          - rust-toolchain.toml
           - nightly
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
       - uses: actions-rs/cargo@v1
+        if: matrix.toolchain == 'rust-toolchain.toml'
         with:
           command: test
+      - run: rustup install ${{ matrix.toolchain }}
+        if: matrix.toolchain != 'rust-toolchain.toml'
+      - uses: actions-rs/cargo@v1
+        if: matrix.toolchain != 'rust-toolchain.toml'
+        with:
+          command: test
+          toolchain: ${{ matrix.toolchain }}
 
   test-os:
     name: Test Suite
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # "windows-latest" was removed; see https://github.com/ZcashFoundation/zcash_script/issues/38
         os: [ubuntu-latest, macOS-latest, windows-latest]
@@ -85,19 +88,8 @@ jobs:
       # - name: install LLVM on Mac
       #   if: matrix.os == 'macOS-latest'
       #   run: brew install llvm
-      - uses: actions-rs/toolchain@v1
+      - run: rustup target add x86_64-pc-windows-msvc
         if: matrix.os == 'windows-latest'
-        with:
-          target: x86_64-pc-windows-msvc
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: actions-rs/toolchain@v1
-        if: matrix.os != 'windows-latest'
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
       - uses: actions-rs/cargo@v1
         if: matrix.os == 'windows-latest'
         with:
@@ -111,19 +103,10 @@ jobs:
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -132,19 +115,10 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,10 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
+// `bindgen::RustTarget::Stable_*` is deprecated in bindgen >= 0.71.0, but we are constrained
+// downstream by the version supported by librocksdb-sys. However, one of our CI jobs still manages
+// to pull a newer version, so this silences the deprecation on that job.
+#[allow(deprecated)]
 fn bindgen_headers() -> Result<()> {
     println!("cargo:rerun-if-changed=depend/zcash/src/script/zcash_script.h");
 
@@ -31,6 +35,9 @@ fn bindgen_headers() -> Result<()> {
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        // This should not reference a version newer than rust-toolchain.toml. See
+        // rust-lang/rust-bindgen#3049 for a potential future solution.
+        .rust_target(bindgen::RustTarget::Stable_1_73)
         // Finish the builder and generate the bindings.
         .generate()
         .map_err(|_| Error::GenerateBindings)?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,4 @@
 [toolchain]
-channel = "stable"
+# TODO: C++ linking on Linux broke in 1.82, but is fixed again in 1.85. This can be bumped once that
+#       is released.
+channel = "1.81"


### PR DESCRIPTION
Matches the one in Zebra, although I think pinning to a specific release (e.g., `channel = "1.82"`) would help with consistency, perhaps avoiding issues like
https://github.com/ZcashFoundation/zcash_script/pull/174#issuecomment-2445336306