### PR TITLE
Bump cc 1.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,13 +189,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ bindgen = ">= 0.64.0"
 # These dependencies are shared with a lot of other Zebra dependencies,
 # so they are configured to automatically upgrade to match Zebra.
 # But we try to use the latest versions here, to catch any bugs in `zcash_script`'s CI.
-cc = { version = "1.0.94", features = ["parallel"] }
+cc = { version = "1.1.10", features = ["parallel"] }
 
 [dev-dependencies]
 # These dependencies are shared with a lot of other Zebra dependencies.

--- a/build.rs
+++ b/build.rs
@@ -199,5 +199,5 @@ fn language_std(build: &mut cc::Build, std: &str) {
         "-std="
     };
 
-    build.flag(&[flag, std].concat());
+    build.flag([flag, std].concat());
 }


### PR DESCRIPTION
I have absolutely no idea why https://github.com/ZcashFoundation/zcash_script/pull/177/ is failing CI due to a clippy issue when it's working on `master`. After trying to figure things out I simply gave up and created the bump PR with the clippy fix