### PR TITLE
Change type of `lock_time` parameter

### DIFF
--- a/fuzz/fuzz_targets/compare.rs
+++ b/fuzz/fuzz_targets/compare.rs
@@ -9,7 +9,7 @@ fn missing_sighash(_script_code: &[u8], _hash_type: HashType) -> Option<[u8; 32]
     None
 }
 
-fuzz_target!(|tup: (i64, bool, &[u8], &[u8], u32)| {
+fuzz_target!(|tup: (u32, bool, &[u8], &[u8], u32)| {
     // `fuzz_target!` doesn’t support pattern matching in the parameter list.
     let (lock_time, is_final, pub_key, sig, flags) = tup;
     let ret = check_verify_callback::<CxxInterpreter, RustInterpreter>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ extern "C" fn sighash_callback(
 impl ZcashScript for CxxInterpreter {
     fn verify_callback(
         sighash: SighashCalculator,
-        lock_time: i64,
+        lock_time: u32,
         is_final: bool,
         script_pub_key: &[u8],
         signature_script: &[u8],
@@ -83,7 +83,7 @@ impl ZcashScript for CxxInterpreter {
             zcash_script_verify_callback(
                 (&sighash as *const SighashCalculator) as *const c_void,
                 Some(sighash_callback),
-                lock_time,
+                lock_time.into(),
                 if is_final { 1 } else { 0 },
                 script_pub_key.as_ptr(),
                 script_pub_key
@@ -137,7 +137,7 @@ fn check_legacy_sigop_count_script<T: ZcashScript, U: ZcashScript>(
 /// differ and always returns the `T` result.
 pub fn check_verify_callback<T: ZcashScript, U: ZcashScript>(
     sighash: SighashCalculator,
-    lock_time: i64,
+    lock_time: u32,
     is_final: bool,
     script_pub_key: &[u8],
     script_sig: &[u8],
@@ -192,7 +192,7 @@ impl ZcashScript for CxxRustComparisonInterpreter {
 
     fn verify_callback(
         sighash: SighashCalculator,
-        lock_time: i64,
+        lock_time: u32,
         is_final: bool,
         script_pub_key: &[u8],
         script_sig: &[u8],
@@ -273,7 +273,7 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let n_lock_time: i64 = 2410374;
+        let n_lock_time: u32 = 2410374;
         let is_final: bool = true;
         let script_pub_key = &SCRIPT_PUBKEY;
         let script_sig = &SCRIPT_SIG;
@@ -294,7 +294,7 @@ mod tests {
 
     #[test]
     fn it_fails_on_invalid_sighash() {
-        let n_lock_time: i64 = 2410374;
+        let n_lock_time: u32 = 2410374;
         let is_final: bool = true;
         let script_pub_key = &SCRIPT_PUBKEY;
         let script_sig = &SCRIPT_SIG;
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn it_fails_on_missing_sighash() {
-        let n_lock_time: i64 = 2410374;
+        let n_lock_time: u32 = 2410374;
         let is_final: bool = true;
         let script_pub_key = &SCRIPT_PUBKEY;
         let script_sig = &SCRIPT_SIG;
@@ -351,7 +351,7 @@ mod tests {
         /// been collapsed to `Error::Ok`. A deeper comparison, requires changes to the C++ code.
         #[test]
         fn test_arbitrary_scripts(
-            lock_time in prop::num::i64::ANY,
+            lock_time in prop::num::u32::ANY,
             is_final in prop::bool::ANY,
             pub_key in prop::collection::vec(0..=0xffu8, 0..=OVERFLOW_SCRIPT_SIZE),
             sig in prop::collection::vec(0..=0xffu8, 1..=OVERFLOW_SCRIPT_SIZE),
@@ -372,7 +372,7 @@ mod tests {
         /// Similar to `test_arbitrary_scripts`, but ensures the `sig` only contains pushes.
         #[test]
         fn test_restricted_sig_scripts(
-            lock_time in prop::num::i64::ANY,
+            lock_time in prop::num::u32::ANY,
             is_final in prop::bool::ANY,
             pub_key in prop::collection::vec(0..=0xffu8, 0..=OVERFLOW_SCRIPT_SIZE),
             sig in prop::collection::vec(0..=0x60u8, 0..=OVERFLOW_SCRIPT_SIZE),

--- a/src/script.rs
+++ b/src/script.rs
@@ -406,14 +406,14 @@ impl ScriptNum {
     }
 }
 
-impl From<i64> for ScriptNum {
-    fn from(value: i64) -> Self {
-        ScriptNum(value)
+impl From<i32> for ScriptNum {
+    fn from(value: i32) -> Self {
+        ScriptNum(value.into())
     }
 }
 
-impl From<i32> for ScriptNum {
-    fn from(value: i32) -> Self {
+impl From<u32> for ScriptNum {
+    fn from(value: u32) -> Self {
         ScriptNum(value.into())
     }
 }

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -35,7 +35,7 @@ pub trait ZcashScript {
     ///  is obtained using a callback function.
     ///
     ///  - sighash: a callback function which is called to obtain the sighash.
-    ///  - n_lock_time: the lock time of the transaction being validated.
+    ///  - lock_time: the lock time of the transaction being validated.
     ///  - is_final: a boolean indicating whether the input being validated is final
     ///    (i.e. its sequence number is 0xFFFFFFFF).
     ///  - script_pub_key: the scriptPubKey of the output being spent.
@@ -45,7 +45,7 @@ pub trait ZcashScript {
     ///  Note that script verification failure is indicated by `Err(Error::Ok)`.
     fn verify_callback(
         sighash_callback: SighashCalculator,
-        lock_time: i64,
+        lock_time: u32,
         is_final: bool,
         script_pub_key: &[u8],
         script_sig: &[u8],
@@ -70,7 +70,7 @@ impl ZcashScript for RustInterpreter {
 
     fn verify_callback(
         sighash: SighashCalculator,
-        lock_time: i64,
+        lock_time: u32,
         is_final: bool,
         script_pub_key: &[u8],
         script_sig: &[u8],


### PR DESCRIPTION
This is a breaking change. Lock times are stored in tx as `u32`, but this API expected `i64`, forcing conversions on the caller. This change brings the API into alignment with the tx representation.