### PR TITLE
Expose `ScriptError` on C++ side

### DIFF
--- a/depend/zcash/src/script/script_error.h
+++ b/depend/zcash/src/script/script_error.h
@@ -53,6 +53,8 @@ typedef enum ScriptError_t
     /* softfork safeness */
     SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS,
 
+    SCRIPT_ERR_VERIFY_SCRIPT,
+
     SCRIPT_ERR_ERROR_COUNT
 } ScriptError;
 

--- a/depend/zcash/src/script/zcash_script.cpp
+++ b/depend/zcash/src/script/zcash_script.cpp
@@ -7,10 +7,11 @@
 #include "zcash_script.h"
 
 #include "script/interpreter.h"
+#include "script/script_error.h"
 #include "version.h"
 
 namespace {
-inline int set_error(zcash_script_error* ret, zcash_script_error serror)
+inline int set_error(ScriptError* ret, ScriptError serror)
 {
     if (ret)
         *ret = serror;
@@ -42,12 +43,10 @@ int zcash_script_verify_callback(
     const unsigned char* scriptSig,
     unsigned int scriptSigLen,
     unsigned int flags,
-    zcash_script_error* err)
+    ScriptError* script_err)
 {
     try {
-        set_error(err, zcash_script_ERR_OK);
         CScriptNum nLockTimeNum = CScriptNum(nLockTime);
-        ScriptError script_err = SCRIPT_ERR_OK;
         return VerifyScript(
             CScript(scriptSig, scriptSig + scriptSigLen),
             CScript(scriptPubKey, scriptPubKey + scriptPubKeyLen),
@@ -56,8 +55,8 @@ int zcash_script_verify_callback(
             // consensusBranchId is not longer used with the callback API; the argument
             // was left there to minimize changes to interpreter.cpp
             0,
-            &script_err);
+            script_err);
     } catch (const std::exception&) {
-        return set_error(err, zcash_script_ERR_VERIFY_SCRIPT);
+        return set_error(script_err, SCRIPT_ERR_VERIFY_SCRIPT);
     }
 }

--- a/depend/zcash/src/script/zcash_script.h
+++ b/depend/zcash/src/script/zcash_script.h
@@ -8,6 +8,7 @@
 #define ZCASH_SCRIPT_ZCASH_SCRIPT_H
 
 #include <stdint.h>
+#include "script_error.h"
 
 #if defined(BUILD_BITCOIN_INTERNAL) && defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"
@@ -35,19 +36,6 @@ extern "C" {
 #endif
 
 #define ZCASH_SCRIPT_API_VER 4
-
-typedef enum zcash_script_error_t
-{
-    zcash_script_ERR_OK = 0,
-    zcash_script_ERR_TX_INDEX,
-    zcash_script_ERR_TX_SIZE_MISMATCH,
-    zcash_script_ERR_TX_DESERIALIZE,
-    // Defined since API version 3.
-    zcash_script_ERR_TX_VERSION,
-    zcash_script_ERR_ALL_PREV_OUTPUTS_SIZE_MISMATCH,
-    zcash_script_ERR_ALL_PREV_OUTPUTS_DESERIALIZE,
-    zcash_script_ERR_VERIFY_SCRIPT,
-} zcash_script_error;
 
 /** Script verification flags */
 enum
@@ -93,8 +81,7 @@ EXPORT_SYMBOL unsigned int zcash_script_legacy_sigop_count_script(
 /// - flags: the script verification flags to use.
 /// - err: if not NULL, err will contain an error/success code for the operation.
 ///
-/// Note that script verification failure is indicated by err being set to
-/// zcash_script_ERR_OK and a return value of 0.
+/// Note that script verification failure is indicated by a return value of 0.
 EXPORT_SYMBOL int zcash_script_verify_callback(
     const void* ctx,
     void (*sighash)(unsigned char* sighash, unsigned int sighashLen, const void* ctx, const unsigned char* scriptCode, unsigned int scriptCodeLen, int hashType),
@@ -105,7 +92,7 @@ EXPORT_SYMBOL int zcash_script_verify_callback(
     const unsigned char* scriptSig,
     unsigned int scriptSigLen,
     unsigned int flags,
-    zcash_script_error* err);
+    ScriptError* err);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/cxx.rs
+++ b/src/cxx.rs
@@ -15,7 +15,6 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 mod tests {
     use std::ffi::{c_int, c_uint, c_void};
 
-    pub use super::zcash_script_error_t;
     use hex::FromHex;
 
     lazy_static::lazy_static! {

--- a/src/script_error.rs
+++ b/src/script_error.rs
@@ -8,8 +8,8 @@ pub enum ScriptNumError {
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum ScriptError {
-    // Ok = 0,
-    UnknownError = 1,
+    Ok = 0, // Unused (except in converting the C++ error to Rust)
+    UnknownError,
     EvalFalse,
     OpReturn,
 
@@ -44,8 +44,8 @@ pub enum ScriptError {
     SigDER,
     MinimalData,
     SigPushOnly,
-    // SigHighS,
-    SigNullDummy = 27,
+    SigHighS, // Unused (except in converting the C++ error to Rust)
+    SigNullDummy,
     PubKeyType,
     CleanStack,
 

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -10,10 +10,7 @@ use super::script_error::*;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Any failure that results in the script being invalid.
-    ///
-    /// __NB__: This is in `Option` because this type is used by both the C++ and Rust
-    ///         implementations, but the C++ impl doesn’t yet expose the original error.
-    Ok(Option<ScriptError>),
+    Ok(ScriptError),
     /// An exception was caught.
     VerifyScript,
     /// The script size can’t fit in a `u32`, as required by the C++ code.
@@ -87,6 +84,6 @@ impl ZcashScript for RustInterpreter {
                 is_final,
             },
         )
-        .map_err(|e| Error::Ok(Some(e)))
+        .map_err(Error::Ok)
     }
 }


### PR DESCRIPTION
**This changes the C++ implementation.**

Provides richer errors, which also gives more precision when comparing against the Rust impl.

This also removes the (now unused) `zcash_script_error_t`. The only case other than `zcash_script_ERR_OK` that was still in use was `zcash_script_ERR_VERIFY_SCRIPT`, so that case has been added to `ScriptError`.

This avoids changing the Rust API, but potentially `Error` and `ScriptError` on the Rust side could be collapsed into one `enum`. It would just be a breaking change.