### PR TITLE
Add various stepwise functionality

### DIFF
--- a/fuzz/fuzz_targets/compare.rs
+++ b/fuzz/fuzz_targets/compare.rs
@@ -3,6 +3,7 @@
 use libfuzzer_sys::fuzz_target;
 extern crate zcash_script;
 
+use zcash_script::interpreter::CallbackTransactionSignatureChecker;
 use zcash_script::*;
 
 fn missing_sighash(_script_code: &[u8], _hash_type: HashType) -> Option<[u8; 32]> {
@@ -11,14 +12,25 @@ fn missing_sighash(_script_code: &[u8], _hash_type: HashType) -> Option<[u8; 32]
 
 fuzz_target!(|tup: (u32, bool, &[u8], &[u8], u32)| {
     // `fuzz_target!` doesn’t support pattern matching in the parameter list.
-    let (lock_time, is_final, pub_key, sig, flags) = tup;
-    let ret = check_verify_callback::<CxxInterpreter, RustInterpreter>(
-        &missing_sighash,
-        lock_time,
-        is_final,
+    let (lock_time, is_final, pub_key, sig, flag_bits) = tup;
+    let flags = testing::repair_flags(VerificationFlags::from_bits_truncate(flag_bits));
+    let ret = check_verify_callback(
+        &CxxInterpreter {
+            sighash: &missing_sighash,
+            lock_time,
+            is_final,
+        },
+        &rust_interpreter(
+            flags,
+            CallbackTransactionSignatureChecker {
+                sighash: &missing_sighash,
+                lock_time: lock_time.into(),
+                is_final,
+            },
+        ),
         pub_key,
         sig,
-        testing::repair_flags(VerificationFlags::from_bits_truncate(flags)),
+        flags,
     );
     assert_eq!(
         ret.0,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -483,11 +483,11 @@ impl State {
 
     /// Creates a state with an initial stack, but other components empty.
     pub fn initial(stack: Stack<Vec<u8>>) -> Self {
-        Self::manual(stack, Stack::new(), 0, Stack::new())
+        Self::from_parts(stack, Stack::new(), 0, Stack::new())
     }
 
-    /// Create an arbitrary stat.
-    pub fn manual(
+    /// Create an arbitrary state.
+    pub fn from_parts(
         stack: Stack<Vec<u8>>,
         altstack: Stack<Vec<u8>>,
         op_count: u8,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -183,6 +183,10 @@ pub struct Stack<T>(Vec<T>);
 /// Wraps a Vec (or whatever underlying implementation we choose in a way that matches the C++ impl
 /// and provides us some decent chaining)
 impl<T: Clone> Stack<T> {
+    pub fn new() -> Self {
+        Stack(vec![])
+    }
+
     fn reverse_index(&self, i: isize) -> Result<usize, ScriptError> {
         usize::try_from(-i)
             .map(|a| self.0.len() - a)
@@ -474,12 +478,12 @@ pub struct State {
 impl State {
     /// Creates a new empty state.
     pub fn new() -> Self {
-        Self::initial(Stack(vec![]))
+        Self::initial(Stack::new())
     }
 
     /// Creates a state with an initial stack, but other components empty.
     pub fn initial(stack: Stack<Vec<u8>>) -> Self {
-        Self::manual(stack, Stack(vec![]), 0, Stack(vec![]))
+        Self::manual(stack, Stack::new(), 0, Stack::new())
     }
 
     /// Create an arbitrary stat.
@@ -1373,7 +1377,7 @@ where
         return set_error(ScriptError::SigPushOnly);
     }
 
-    let data_stack = eval_script(Stack(Vec::new()), script_sig, payload, stepper)?;
+    let data_stack = eval_script(Stack::new(), script_sig, payload, stepper)?;
     let pub_key_stack = eval_script(data_stack.clone(), script_pub_key, payload, stepper)?;
     if pub_key_stack.empty() {
         return set_error(ScriptError::EvalFalse);

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -177,7 +177,7 @@ fn cast_to_bool(vch: &ValType) -> bool {
  * Script is a stack machine (like Forth) that evaluates a predicate
  * returning a bool indicating valid or not.  There are no loops.
  */
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Stack<T>(Vec<T>);
 
 /// Wraps a Vec (or whatever underlying implementation we choose in a way that matches the C++ impl
@@ -462,7 +462,7 @@ fn check_minimal_push(data: &[u8], opcode: PushValue) -> bool {
 const VCH_FALSE: ValType = Vec::new();
 const VCH_TRUE: [u8; 1] = [1];
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct State {
     stack: Stack<Vec<u8>>,
     altstack: Stack<Vec<u8>>,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -447,6 +447,29 @@ fn check_minimal_push(data: &[u8], opcode: PushValue) -> bool {
 const VCH_FALSE: ValType = Vec::new();
 const VCH_TRUE: [u8; 1] = [1];
 
+pub struct State<'a> {
+    stack: &'a mut Stack<Vec<u8>>,
+    altstack: Stack<Vec<u8>>,
+    // We keep track of how many operations have executed so far to prevent expensive-to-verify
+    // scripts
+    op_count: u8,
+    // This keeps track of the conditional flags at each nesting level during execution. If we're in
+    // a branch of execution where *any* of these conditionals are false, we ignore opcodes unless
+    // those opcodes direct control flow (OP_IF, OP_ELSE, etc.).
+    vexec: Stack<bool>,
+}
+
+impl<'a> State<'a> {
+    pub fn initial(stack: &'a mut Stack<Vec<u8>>) -> Self {
+        State {
+            stack,
+            altstack: Stack(vec![]),
+            op_count: 0,
+            vexec: Stack(vec![]),
+        }
+    }
+}
+
 /// Run a single step of the interpreter.
 ///
 /// This is useful for testing & debugging, as we can set up the exact state we want in order to
@@ -456,12 +479,13 @@ pub fn eval_step(
     script: &Script,
     flags: VerificationFlags,
     checker: &dyn SignatureChecker,
-    stack: &mut Stack<Vec<u8>>,
-    altstack: &mut Stack<Vec<u8>>,
-    op_count: &mut u8,
-    vexec: &mut Stack<bool>,
+    state: &mut State,
 ) -> Result<(), ScriptError> {
+    let stack = &mut state.stack;
+    let op_count = &mut state.op_count;
     let require_minimal = flags.contains(VerificationFlags::MinimalData);
+    let vexec = &mut state.vexec;
+    let altstack = &mut state.altstack;
 
     // Are we in an executing branch of the script?
     let exec = vexec.iter().all(|value| *value);
@@ -1175,33 +1199,14 @@ pub fn eval_script(
 
     let mut pc = script.0;
 
-    // We keep track of how many operations have executed so far to prevent
-    // expensive-to-verify scripts
-    let mut op_count: u8 = 0;
-
-    // This keeps track of the conditional flags at each nesting level
-    // during execution. If we're in a branch of execution where *any*
-    // of these conditionals are false, we ignore opcodes unless those
-    // opcodes direct control flow (OP_IF, OP_ELSE, etc.).
-    let mut vexec: Stack<bool> = Stack(vec![]);
-
-    let mut altstack: Stack<Vec<u8>> = Stack(vec![]);
+    let mut state = State::initial(stack);
 
     // Main execution loop
     while !pc.is_empty() {
-        eval_step(
-            &mut pc,
-            script,
-            flags,
-            checker,
-            stack,
-            &mut altstack,
-            &mut op_count,
-            &mut vexec,
-        )?;
+        eval_step(&mut pc, script, flags, checker, &mut state)?;
     }
 
-    if !vexec.empty() {
+    if !state.vexec.empty() {
         return set_error(ScriptError::UnbalancedConditional);
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -460,25 +460,57 @@ const VCH_TRUE: [u8; 1] = [1];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct State {
-    pub stack: Stack<Vec<u8>>,
-    pub altstack: Stack<Vec<u8>>,
+    stack: Stack<Vec<u8>>,
+    altstack: Stack<Vec<u8>>,
     // We keep track of how many operations have executed so far to prevent expensive-to-verify
     // scripts
-    pub op_count: u8,
+    op_count: u8,
     // This keeps track of the conditional flags at each nesting level during execution. If we're in
     // a branch of execution where *any* of these conditionals are false, we ignore opcodes unless
     // those opcodes direct control flow (OP_IF, OP_ELSE, etc.).
-    pub vexec: Stack<bool>,
+    vexec: Stack<bool>,
 }
 
 impl State {
+    /// Creates a new empty state.
+    pub fn new() -> Self {
+        Self::initial(Stack(vec![]))
+    }
+
+    /// Creates a state with an initial stack, but other components empty.
     pub fn initial(stack: Stack<Vec<u8>>) -> Self {
+        Self::manual(stack, Stack(vec![]), 0, Stack(vec![]))
+    }
+
+    /// Create an arbitrary stat.
+    pub fn manual(
+        stack: Stack<Vec<u8>>,
+        altstack: Stack<Vec<u8>>,
+        op_count: u8,
+        vexec: Stack<bool>,
+    ) -> Self {
         State {
             stack,
-            altstack: Stack(vec![]),
-            op_count: 0,
-            vexec: Stack(vec![]),
+            altstack,
+            op_count,
+            vexec,
         }
+    }
+
+    pub fn stack(&self) -> &Stack<Vec<u8>> {
+        &self.stack
+    }
+
+    pub fn altstack(&self) -> &Stack<Vec<u8>> {
+        &self.altstack
+    }
+
+    pub fn op_count(&self) -> u8 {
+        self.op_count
+    }
+
+    pub fn vexec(&self) -> &Stack<bool> {
+        &self.vexec
     }
 }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -146,7 +146,7 @@ impl SignatureChecker for BaseSignatureChecker {}
 #[derive(Copy, Clone)]
 pub struct CallbackTransactionSignatureChecker<'a> {
     pub sighash: SighashCalculator<'a>,
-    pub lock_time: &'a ScriptNum,
+    pub lock_time: ScriptNum,
     pub is_final: bool,
 }
 
@@ -1304,11 +1304,11 @@ impl SignatureChecker for CallbackTransactionSignatureChecker<'_> {
         // We want to compare apples to apples, so fail the script
         // unless the type of nLockTime being tested is the same as
         // the nLockTime in the transaction.
-        if *self.lock_time < LOCKTIME_THRESHOLD && *lock_time >= LOCKTIME_THRESHOLD
-            || *self.lock_time >= LOCKTIME_THRESHOLD && *lock_time < LOCKTIME_THRESHOLD
+        if self.lock_time < LOCKTIME_THRESHOLD && *lock_time >= LOCKTIME_THRESHOLD
+            || self.lock_time >= LOCKTIME_THRESHOLD && *lock_time < LOCKTIME_THRESHOLD
             // Now that we know we're comparing apples-to-apples, the
             // comparison is a simple numeric one.
-            || lock_time > self.lock_time
+            || *lock_time > self.lock_time
         {
             false
             // Finally the nLockTime feature can be disabled and thus

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1198,7 +1198,7 @@ pub fn eval_step<'a>(
 }
 
 pub trait StepFn {
-    type Payload;
+    type Payload: Clone;
     fn call<'a>(
         &self,
         pc: &'a [u8],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@
 #[macro_use]
 extern crate enum_primitive;
 
-mod cxx;
+pub mod cxx;
 mod external;
-mod interpreter;
+pub mod interpreter;
 mod script;
 pub mod script_error;
 mod zcash_script;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,11 @@ use std::os::raw::{c_int, c_uint, c_void};
 
 use tracing::warn;
 
-pub use cxx::*;
 pub use interpreter::{
     CallbackTransactionSignatureChecker, DefaultStepEvaluator, HashType, SighashCalculator,
     SignedOutputs, VerificationFlags,
 };
+use script_error::ScriptError;
 pub use zcash_script::*;
 
 /// A tag to indicate that the C++ implementation of zcash_script should be used.
@@ -36,81 +36,59 @@ impl From<cxx::ScriptError> for Error {
     #[allow(non_upper_case_globals)]
     fn from(err_code: cxx::ScriptError) -> Self {
         match err_code {
-            ScriptError_t_SCRIPT_ERR_OK => Error::Ok(script_error::ScriptError::Ok),
-            ScriptError_t_SCRIPT_ERR_UNKNOWN_ERROR => {
-                Error::Ok(script_error::ScriptError::UnknownError)
-            }
-            ScriptError_t_SCRIPT_ERR_EVAL_FALSE => Error::Ok(script_error::ScriptError::EvalFalse),
-            ScriptError_t_SCRIPT_ERR_OP_RETURN => Error::Ok(script_error::ScriptError::OpReturn),
+            cxx::ScriptError_t_SCRIPT_ERR_OK => Error::Ok(ScriptError::Ok),
+            cxx::ScriptError_t_SCRIPT_ERR_UNKNOWN_ERROR => Error::Ok(ScriptError::UnknownError),
+            cxx::ScriptError_t_SCRIPT_ERR_EVAL_FALSE => Error::Ok(ScriptError::EvalFalse),
+            cxx::ScriptError_t_SCRIPT_ERR_OP_RETURN => Error::Ok(ScriptError::OpReturn),
 
-            ScriptError_t_SCRIPT_ERR_SCRIPT_SIZE => {
-                Error::Ok(script_error::ScriptError::ScriptSize)
-            }
-            ScriptError_t_SCRIPT_ERR_PUSH_SIZE => Error::Ok(script_error::ScriptError::PushSize),
-            ScriptError_t_SCRIPT_ERR_OP_COUNT => Error::Ok(script_error::ScriptError::OpCount),
-            ScriptError_t_SCRIPT_ERR_STACK_SIZE => Error::Ok(script_error::ScriptError::StackSize),
-            ScriptError_t_SCRIPT_ERR_SIG_COUNT => Error::Ok(script_error::ScriptError::SigCount),
-            ScriptError_t_SCRIPT_ERR_PUBKEY_COUNT => {
-                Error::Ok(script_error::ScriptError::PubKeyCount)
-            }
+            cxx::ScriptError_t_SCRIPT_ERR_SCRIPT_SIZE => Error::Ok(ScriptError::ScriptSize),
+            cxx::ScriptError_t_SCRIPT_ERR_PUSH_SIZE => Error::Ok(ScriptError::PushSize),
+            cxx::ScriptError_t_SCRIPT_ERR_OP_COUNT => Error::Ok(ScriptError::OpCount),
+            cxx::ScriptError_t_SCRIPT_ERR_STACK_SIZE => Error::Ok(ScriptError::StackSize),
+            cxx::ScriptError_t_SCRIPT_ERR_SIG_COUNT => Error::Ok(ScriptError::SigCount),
+            cxx::ScriptError_t_SCRIPT_ERR_PUBKEY_COUNT => Error::Ok(ScriptError::PubKeyCount),
 
-            ScriptError_t_SCRIPT_ERR_VERIFY => Error::Ok(script_error::ScriptError::Verify),
-            ScriptError_t_SCRIPT_ERR_EQUALVERIFY => {
-                Error::Ok(script_error::ScriptError::EqualVerify)
+            cxx::ScriptError_t_SCRIPT_ERR_VERIFY => Error::Ok(ScriptError::Verify),
+            cxx::ScriptError_t_SCRIPT_ERR_EQUALVERIFY => Error::Ok(ScriptError::EqualVerify),
+            cxx::ScriptError_t_SCRIPT_ERR_CHECKMULTISIGVERIFY => {
+                Error::Ok(ScriptError::CheckMultisigVerify)
             }
-            ScriptError_t_SCRIPT_ERR_CHECKMULTISIGVERIFY => {
-                Error::Ok(script_error::ScriptError::CheckMultisigVerify)
-            }
-            ScriptError_t_SCRIPT_ERR_CHECKSIGVERIFY => {
-                Error::Ok(script_error::ScriptError::CheckSigVerify)
-            }
-            ScriptError_t_SCRIPT_ERR_NUMEQUALVERIFY => {
-                Error::Ok(script_error::ScriptError::NumEqualVerify)
-            }
+            cxx::ScriptError_t_SCRIPT_ERR_CHECKSIGVERIFY => Error::Ok(ScriptError::CheckSigVerify),
+            cxx::ScriptError_t_SCRIPT_ERR_NUMEQUALVERIFY => Error::Ok(ScriptError::NumEqualVerify),
 
-            ScriptError_t_SCRIPT_ERR_BAD_OPCODE => Error::Ok(script_error::ScriptError::BadOpcode),
-            ScriptError_t_SCRIPT_ERR_DISABLED_OPCODE => {
-                Error::Ok(script_error::ScriptError::DisabledOpcode)
+            cxx::ScriptError_t_SCRIPT_ERR_BAD_OPCODE => Error::Ok(ScriptError::BadOpcode),
+            cxx::ScriptError_t_SCRIPT_ERR_DISABLED_OPCODE => Error::Ok(ScriptError::DisabledOpcode),
+            cxx::ScriptError_t_SCRIPT_ERR_INVALID_STACK_OPERATION => {
+                Error::Ok(ScriptError::InvalidStackOperation)
             }
-            ScriptError_t_SCRIPT_ERR_INVALID_STACK_OPERATION => {
-                Error::Ok(script_error::ScriptError::InvalidStackOperation)
+            cxx::ScriptError_t_SCRIPT_ERR_INVALID_ALTSTACK_OPERATION => {
+                Error::Ok(ScriptError::InvalidAltstackOperation)
             }
-            ScriptError_t_SCRIPT_ERR_INVALID_ALTSTACK_OPERATION => {
-                Error::Ok(script_error::ScriptError::InvalidAltstackOperation)
-            }
-            ScriptError_t_SCRIPT_ERR_UNBALANCED_CONDITIONAL => {
-                Error::Ok(script_error::ScriptError::UnbalancedConditional)
+            cxx::ScriptError_t_SCRIPT_ERR_UNBALANCED_CONDITIONAL => {
+                Error::Ok(ScriptError::UnbalancedConditional)
             }
 
-            ScriptError_t_SCRIPT_ERR_NEGATIVE_LOCKTIME => {
-                Error::Ok(script_error::ScriptError::NegativeLockTime)
+            cxx::ScriptError_t_SCRIPT_ERR_NEGATIVE_LOCKTIME => {
+                Error::Ok(ScriptError::NegativeLockTime)
             }
-            ScriptError_t_SCRIPT_ERR_UNSATISFIED_LOCKTIME => {
-                Error::Ok(script_error::ScriptError::UnsatisfiedLockTime)
-            }
-
-            ScriptError_t_SCRIPT_ERR_SIG_HASHTYPE => {
-                Error::Ok(script_error::ScriptError::SigHashType)
-            }
-            ScriptError_t_SCRIPT_ERR_SIG_DER => Error::Ok(script_error::ScriptError::SigDER),
-            ScriptError_t_SCRIPT_ERR_MINIMALDATA => {
-                Error::Ok(script_error::ScriptError::MinimalData)
-            }
-            ScriptError_t_SCRIPT_ERR_SIG_PUSHONLY => {
-                Error::Ok(script_error::ScriptError::SigPushOnly)
-            }
-            ScriptError_t_SCRIPT_ERR_SIG_HIGH_S => Error::Ok(script_error::ScriptError::SigHighS),
-            ScriptError_t_SCRIPT_ERR_SIG_NULLDUMMY => {
-                Error::Ok(script_error::ScriptError::SigNullDummy)
-            }
-            ScriptError_t_SCRIPT_ERR_PUBKEYTYPE => Error::Ok(script_error::ScriptError::PubKeyType),
-            ScriptError_t_SCRIPT_ERR_CLEANSTACK => Error::Ok(script_error::ScriptError::CleanStack),
-
-            ScriptError_t_SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS => {
-                Error::Ok(script_error::ScriptError::DiscourageUpgradableNOPs)
+            cxx::ScriptError_t_SCRIPT_ERR_UNSATISFIED_LOCKTIME => {
+                Error::Ok(ScriptError::UnsatisfiedLockTime)
             }
 
-            ScriptError_t_SCRIPT_ERR_VERIFY_SCRIPT => Error::VerifyScript,
+            cxx::ScriptError_t_SCRIPT_ERR_SIG_HASHTYPE => Error::Ok(ScriptError::SigHashType),
+            cxx::ScriptError_t_SCRIPT_ERR_SIG_DER => Error::Ok(ScriptError::SigDER),
+            cxx::ScriptError_t_SCRIPT_ERR_MINIMALDATA => Error::Ok(ScriptError::MinimalData),
+            cxx::ScriptError_t_SCRIPT_ERR_SIG_PUSHONLY => Error::Ok(ScriptError::SigPushOnly),
+            cxx::ScriptError_t_SCRIPT_ERR_SIG_HIGH_S => Error::Ok(ScriptError::SigHighS),
+            cxx::ScriptError_t_SCRIPT_ERR_SIG_NULLDUMMY => Error::Ok(ScriptError::SigNullDummy),
+            cxx::ScriptError_t_SCRIPT_ERR_PUBKEYTYPE => Error::Ok(ScriptError::PubKeyType),
+            cxx::ScriptError_t_SCRIPT_ERR_CLEANSTACK => Error::Ok(ScriptError::CleanStack),
+
+            cxx::ScriptError_t_SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS => {
+                Error::Ok(ScriptError::DiscourageUpgradableNOPs)
+            }
+
+            cxx::ScriptError_t_SCRIPT_ERR_VERIFY_SCRIPT => Error::VerifyScript,
             unknown => Error::Unknown(unknown.into()),
         }
     }
@@ -161,7 +139,7 @@ impl<'a> ZcashScript for CxxInterpreter<'a> {
 
         // SAFETY: The `script` fields are created from a valid Rust `slice`.
         let ret = unsafe {
-            zcash_script_verify_callback(
+            cxx::zcash_script_verify_callback(
                 (&self.sighash as *const SighashCalculator) as *const c_void,
                 Some(sighash_callback),
                 self.lock_time.into(),
@@ -196,7 +174,7 @@ impl<'a> ZcashScript for CxxInterpreter<'a> {
             .try_into()
             .map_err(Error::InvalidScriptSize)
             .map(|script_len| unsafe {
-                zcash_script_legacy_sigop_count_script(script.as_ptr(), script_len)
+                cxx::zcash_script_legacy_sigop_count_script(script.as_ptr(), script_len)
             })
     }
 }
@@ -235,8 +213,8 @@ pub fn check_verify_callback<T: ZcashScript, U: ZcashScript>(
 pub fn normalize_error(err: Error) -> Error {
     match err {
         Error::Ok(serr) => Error::Ok(match serr {
-            script_error::ScriptError::ReadError { .. } => script_error::ScriptError::BadOpcode,
-            script_error::ScriptError::ScriptNumError(_) => script_error::ScriptError::UnknownError,
+            ScriptError::ReadError { .. } => ScriptError::BadOpcode,
+            ScriptError::ScriptNumError(_) => ScriptError::UnknownError,
             _ => serr,
         }),
         _ => err,
@@ -347,7 +325,7 @@ pub mod testing {
             script: &Script,
             state: &mut State,
             payload: &mut T::Payload,
-        ) -> Result<&'a [u8], script_error::ScriptError> {
+        ) -> Result<&'a [u8], ScriptError> {
             self.0.call(
                 if pc[0] == Operation::OP_EQUAL.into() {
                     &pc[1..]
@@ -451,7 +429,7 @@ mod tests {
         );
 
         assert_eq!(ret.0, ret.1.map_err(normalize_error));
-        assert_eq!(ret.0, Err(Error::Ok(script_error::ScriptError::EvalFalse)));
+        assert_eq!(ret.0, Err(Error::Ok(ScriptError::EvalFalse)));
     }
 
     #[test]
@@ -482,7 +460,7 @@ mod tests {
         );
 
         assert_eq!(ret.0, ret.1.map_err(normalize_error));
-        assert_eq!(ret.0, Err(Error::Ok(script_error::ScriptError::EvalFalse)));
+        assert_eq!(ret.0, Err(Error::Ok(ScriptError::EvalFalse)));
     }
 
     proptest! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ pub use interpreter::{
 use script_error::ScriptError;
 pub use zcash_script::*;
 
-/// A tag to indicate that the C++ implementation of zcash_script should be used.
 pub struct CxxInterpreter<'a> {
     pub sighash: SighashCalculator<'a>,
     pub lock_time: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,7 +476,7 @@ mod tests {
             sig in prop::collection::vec(0..=0xffu8, 1..=OVERFLOW_SCRIPT_SIZE),
             flag_bits in prop::bits::u32::masked(VerificationFlags::all().bits()),
         ) {
-            let flags =                 repair_flags(VerificationFlags::from_bits_truncate(flag_bits));
+            let flags = repair_flags(VerificationFlags::from_bits_truncate(flag_bits));
             let ret = check_verify_callback(
             &CxxInterpreter {
                 sighash: &sighash,

--- a/src/script.rs
+++ b/src/script.rs
@@ -269,6 +269,9 @@ impl From<Operation> for u8 {
 pub struct ScriptNum(i64);
 
 impl ScriptNum {
+    pub const ZERO: ScriptNum = ScriptNum(0);
+    pub const ONE: ScriptNum = ScriptNum(1);
+
     const DEFAULT_MAX_NUM_SIZE: usize = 4;
 
     pub fn new(

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -243,7 +243,7 @@ mod tests {
 
         let checker = CallbackTransactionSignatureChecker {
             sighash: &sighash,
-            lock_time: &n_lock_time.into(),
+            lock_time: n_lock_time.into(),
             is_final,
         };
         let rust_stepper = DefaultStepEvaluator { flags, checker };
@@ -270,7 +270,7 @@ mod tests {
 
         let checker = CallbackTransactionSignatureChecker {
             sighash: &sighash,
-            lock_time: &n_lock_time.into(),
+            lock_time: n_lock_time.into(),
             is_final,
         };
         let rust_stepper = DefaultStepEvaluator { flags, checker };
@@ -335,7 +335,7 @@ mod tests {
 
         let checker = CallbackTransactionSignatureChecker {
             sighash: &invalid_sighash,
-            lock_time: &n_lock_time.into(),
+            lock_time: n_lock_time.into(),
             is_final,
         };
         let rust_stepper = DefaultStepEvaluator { flags, checker };
@@ -362,7 +362,7 @@ mod tests {
 
         let checker = CallbackTransactionSignatureChecker {
             sighash: &missing_sighash,
-            lock_time: &n_lock_time.into(),
+            lock_time: n_lock_time.into(),
             is_final,
         };
         let rust_stepper = DefaultStepEvaluator { flags, checker };
@@ -396,7 +396,7 @@ mod tests {
         ) {
             let checker = CallbackTransactionSignatureChecker {
                 sighash: &missing_sighash,
-                lock_time: &lock_time.into(),
+                lock_time: lock_time.into(),
                 is_final,
             };
             let flags = repair_flags(VerificationFlags::from_bits_truncate(flags));
@@ -424,10 +424,9 @@ mod tests {
                 // Don’t waste test cases on whether or not `SigPushOnly` is set.
                 (VerificationFlags::all() - VerificationFlags::SigPushOnly).bits()),
         ) {
-            let lt = lock_time.into();
             let checker = CallbackTransactionSignatureChecker {
                 sighash: &missing_sighash,
-                lock_time: &lt,
+                lock_time: lock_time.into(),
                 is_final,
             };
             let flags = repair_flags(VerificationFlags::from_bits_truncate(flags)) | VerificationFlags::SigPushOnly;

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -58,13 +58,16 @@ pub trait ZcashScript {
 pub enum RustInterpreter {}
 
 impl RustInterpreter {
-    fn verify<T>(
-        script_sig: &[u8],
+    pub fn verify<F>(
         script_pub_key: &[u8],
+        script_sig: &[u8],
         flags: VerificationFlags,
-        payload: &mut T,
-        stepper: &impl Fn(&mut &[u8], &Script, &mut State, &mut T) -> Result<(), ScriptError>,
-    ) -> Result<(), Error> {
+        payload: &mut F::Payload,
+        stepper: &F,
+    ) -> Result<(), Error>
+    where
+        F: StepFn,
+    {
         verify_script(
             &Script(script_sig),
             &Script(script_pub_key),
@@ -73,6 +76,90 @@ impl RustInterpreter {
             stepper,
         )
         .map_err(Error::Ok)
+    }
+}
+
+/// A payload for comparing the results of two steppers.
+#[derive(Debug, PartialEq, Eq)]
+pub struct StepResults<'a, T, U> {
+    /// This contains the step-wise states of the steppers as long as they were identical. Its
+    /// `head` contains the initial state and its `tail` has a 1:1 correspondence to the opcodes
+    /// (not to the bytes).
+    pub identical_states: Vec<State>,
+    /// If the execution matched the entire way, then this contains `None`. If there was a
+    /// divergence, then this contains `Some` with a pair of `Result`s – one representing each
+    /// stepper’s outcome at the point at which they diverged.
+    pub diverging_result: Option<(Result<State, ScriptError>, Result<State, ScriptError>)>,
+    /// The final payload of the first stepper.
+    pub payload_l: &'a mut T,
+    /// The final payload of the second stepper.
+    pub payload_r: &'a mut U,
+}
+
+impl<'a, T, U> StepResults<'a, T, U> {
+    pub fn initial(payload_l: &'a mut T, payload_r: &'a mut U) -> Self {
+        StepResults {
+            identical_states: vec![],
+            diverging_result: None,
+            payload_l,
+            payload_r,
+        }
+    }
+}
+
+/// This compares two `ZcashScript` implementations in a deep way – checking the entire `State` step
+/// by step. Note that this has some tradeoffs: one is performance. Another is that it doesn’t run
+/// the entire codepath of either implementation. The setup/wrapup code is specific to this
+/// definition, but any differences there should be caught very easily by other testing mechanisms
+/// (like `check_verify_callback`).
+///
+/// This returns a very debuggable result. See `StepResults` for details.
+pub struct ComparisonStepEvaluator<'a, T, U> {
+    pub eval_step_l: &'a dyn StepFn<Payload = T>,
+    pub eval_step_r: &'a dyn StepFn<Payload = U>,
+}
+
+impl<'a, T, U> StepFn for ComparisonStepEvaluator<'a, T, U> {
+    type Payload = StepResults<'a, T, U>;
+    fn call<'b>(
+        &self,
+        pc: &'b [u8],
+        script: &Script,
+        state: &mut State,
+        payload: &mut StepResults<'a, T, U>,
+    ) -> Result<&'b [u8], ScriptError> {
+        let mut right_state = (*state).clone();
+        let left = self.eval_step_l.call(pc, script, state, payload.payload_l);
+        let right = self
+            .eval_step_r
+            .call(pc, script, &mut right_state, payload.payload_r);
+
+        match (left, right) {
+            (Ok(_), Ok(_)) => {
+                if *state == right_state {
+                    payload.identical_states.push(state.clone());
+                    left
+                } else {
+                    // In this case, the script hasn’t failed, but we stop running
+                    // anything
+                    payload.diverging_result = Some((
+                        left.map(|_| state.clone()),
+                        right.map(|_| right_state.clone()),
+                    ));
+                    Err(ScriptError::UnknownError)
+                }
+            }
+            // at least one is `Err`
+            (_, _) => {
+                if left != right {
+                    payload.diverging_result = Some((
+                        left.map(|_| state.clone()),
+                        right.map(|_| right_state.clone()),
+                    ));
+                }
+                left.and(right)
+            }
+        }
     }
 }
 
@@ -98,7 +185,310 @@ impl ZcashScript for RustInterpreter {
             lock_time: &lock_time_num,
             is_final,
         };
-        let stepper = eval_step2(flags, &checker);
-        Self::verify(script_sig, script_pub_key, flags, &mut (), &stepper)
+        let stepper = DefaultStepEvaluator { flags, checker };
+        Self::verify(script_pub_key, script_sig, flags, &mut (), &stepper)
+    }
+}
+
+#[cfg(any(test, feature = "test-dependencies"))]
+pub mod testing {
+    use super::*;
+
+    /// Ensures that flags represent a supported state. This avoids crashes in the C++ code, which
+    /// break various tests.
+    pub fn repair_flags(flags: VerificationFlags) -> VerificationFlags {
+        // TODO: The C++ implementation fails an assert (interpreter.cpp:1097) if `CleanStack` is
+        //       set without `P2SH`.
+        if flags.contains(VerificationFlags::CleanStack) {
+            flags & VerificationFlags::P2SH
+        } else {
+            flags
+        }
+    }
+
+    /// A `usize` one larger than the longest allowed script, for testing bounds.
+    pub const OVERFLOW_SCRIPT_SIZE: usize = MAX_SCRIPT_SIZE + 1;
+
+    /// This is the same as `DefaultStepEvaluator`, except that it skips `OP_EQUAL`, allowing us to
+    /// test comparison failures.
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct BrokenStepEvaluator<T>(pub T);
+
+    impl<T: StepFn> StepFn for BrokenStepEvaluator<T> {
+        type Payload = T::Payload;
+        fn call<'a>(
+            &self,
+            pc: &'a [u8],
+            script: &Script,
+            state: &mut State,
+            payload: &mut T::Payload,
+        ) -> Result<&'a [u8], ScriptError> {
+            self.0.call(
+                if pc[0] == Operation::OP_EQUAL.into() {
+                    &pc[1..]
+                } else {
+                    pc
+                },
+                script,
+                state,
+                payload,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{testing::*, *};
+    use hex::FromHex;
+    use proptest::prelude::*;
+
+    lazy_static::lazy_static! {
+        pub static ref SCRIPT_PUBKEY: Vec<u8> = <Vec<u8>>::from_hex("a914c117756dcbe144a12a7c33a77cfa81aa5aeeb38187").unwrap();
+        pub static ref SCRIPT_SIG: Vec<u8> = <Vec<u8>>::from_hex("00483045022100d2ab3e6258fe244fa442cfb38f6cef9ac9a18c54e70b2f508e83fa87e20d040502200eead947521de943831d07a350e45af8e36c2166984a8636f0a8811ff03ed09401473044022013e15d865010c257eef133064ef69a780b4bc7ebe6eda367504e806614f940c3022062fdbc8c2d049f91db2042d6c9771de6f1ef0b3b1fea76c1ab5542e44ed29ed8014c69522103b2cc71d23eb30020a4893982a1e2d352da0d20ee657fa02901c432758909ed8f21029d1e9a9354c0d2aee9ffd0f0cea6c39bbf98c4066cf143115ba2279d0ba7dabe2103e32096b63fd57f3308149d238dcbb24d8d28aad95c0e4e74e3e5e6a11b61bcc453ae").expect("Block bytes are in valid hex representation");
+    }
+
+    fn sighash(_script_code: &[u8], _hash_type: HashType) -> Option<[u8; 32]> {
+        hex::decode("e8c7bdac77f6bb1f3aba2eaa1fada551a9c8b3b5ecd1ef86e6e58a5f1aab952c")
+            .unwrap()
+            .as_slice()
+            .first_chunk::<32>()
+            .copied()
+    }
+
+    fn invalid_sighash(_script_code: &[u8], _hash_type: HashType) -> Option<[u8; 32]> {
+        hex::decode("08c7bdac77f6bb1f3aba2eaa1fada551a9c8b3b5ecd1ef86e6e58a5f1aab952c")
+            .unwrap()
+            .as_slice()
+            .first_chunk::<32>()
+            .copied()
+    }
+
+    fn missing_sighash(_script_code: &[u8], _hash_type: HashType) -> Option<[u8; 32]> {
+        None
+    }
+
+    #[test]
+    fn it_works() {
+        let n_lock_time: u32 = 2410374;
+        let is_final: bool = true;
+        let script_pub_key = &SCRIPT_PUBKEY;
+        let script_sig = &SCRIPT_SIG;
+        let flags = VerificationFlags::P2SH | VerificationFlags::CHECKLOCKTIMEVERIFY;
+
+        let checker = CallbackTransactionSignatureChecker {
+            sighash: &sighash,
+            lock_time: &n_lock_time.into(),
+            is_final,
+        };
+        let mut payload_l = ();
+        let mut payload_r = ();
+        let rust_stepper = DefaultStepEvaluator { flags, checker };
+        let stepper = ComparisonStepEvaluator {
+            eval_step_l: &rust_stepper,
+            eval_step_r: &rust_stepper,
+        };
+        let mut res = StepResults::initial(&mut payload_l, &mut payload_r);
+        let ret = RustInterpreter::verify(script_pub_key, script_sig, flags, &mut res, &stepper);
+
+        if res.diverging_result != None {
+            panic!("invalid result: {:?}", res);
+        }
+        assert_eq!(ret, Ok(()));
+    }
+
+    #[test]
+    fn broken_stepper_causes_divergence() {
+        let n_lock_time: u32 = 2410374;
+        let is_final: bool = true;
+        let script_pub_key = &SCRIPT_PUBKEY;
+        let script_sig = &SCRIPT_SIG;
+        let flags = VerificationFlags::P2SH | VerificationFlags::CHECKLOCKTIMEVERIFY;
+
+        let checker = CallbackTransactionSignatureChecker {
+            sighash: &sighash,
+            lock_time: &n_lock_time.into(),
+            is_final,
+        };
+        let mut payload_l = ();
+        let mut payload_r = ();
+        let rust_stepper = DefaultStepEvaluator { flags, checker };
+        let broken_stepper = BrokenStepEvaluator(rust_stepper);
+        let stepper = ComparisonStepEvaluator {
+            eval_step_l: &rust_stepper,
+            eval_step_r: &broken_stepper,
+        };
+        let mut res = StepResults::initial(&mut payload_l, &mut payload_r);
+        let ret = RustInterpreter::verify(script_pub_key, script_sig, flags, &mut res, &stepper);
+
+        // The final return value is from whichever stepper failed.
+        assert_eq!(
+            ret,
+            Err(Error::Ok(ScriptError::ReadError {
+                expected_bytes: 1,
+                available_bytes: 0,
+            }))
+        );
+
+        // `State`s are large, so we just check that there was some progress in lock step, and a
+        // divergence.
+        match res {
+            StepResults {
+                identical_states,
+                diverging_result:
+                    Some((
+                        Ok(State {
+                            stack,
+                            altstack,
+                            op_count: 2,
+                            vexec,
+                        }),
+                        Err(ScriptError::ReadError {
+                            expected_bytes: 1,
+                            available_bytes: 0,
+                        }),
+                    )),
+                payload_l: (),
+                payload_r: (),
+            } => {
+                assert!(
+                    identical_states.len() == 6
+                        && stack.size() == 4
+                        && altstack.empty()
+                        && vexec.empty()
+                );
+            }
+            _ => {
+                panic!("invalid result: {:?}", res);
+            }
+        }
+    }
+
+    #[test]
+    fn it_fails_on_invalid_sighash() {
+        let n_lock_time: u32 = 2410374;
+        let is_final: bool = true;
+        let script_pub_key = &SCRIPT_PUBKEY;
+        let script_sig = &SCRIPT_SIG;
+        let flags = VerificationFlags::P2SH | VerificationFlags::CHECKLOCKTIMEVERIFY;
+
+        let checker = CallbackTransactionSignatureChecker {
+            sighash: &invalid_sighash,
+            lock_time: &n_lock_time.into(),
+            is_final,
+        };
+        let mut payload_l = ();
+        let mut payload_r = ();
+        let rust_stepper = DefaultStepEvaluator { flags, checker };
+        let stepper = ComparisonStepEvaluator {
+            eval_step_l: &rust_stepper,
+            eval_step_r: &rust_stepper,
+        };
+        let mut res = StepResults::initial(&mut payload_l, &mut payload_r);
+        let ret = RustInterpreter::verify(script_pub_key, script_sig, flags, &mut res, &stepper);
+
+        if res.diverging_result != None {
+            panic!("mismatched result: {:?}", res);
+        }
+        assert_eq!(ret, Err(Error::Ok(ScriptError::EvalFalse)));
+    }
+
+    #[test]
+    fn it_fails_on_missing_sighash() {
+        let n_lock_time: u32 = 2410374;
+        let is_final: bool = true;
+        let script_pub_key = &SCRIPT_PUBKEY;
+        let script_sig = &SCRIPT_SIG;
+        let flags = VerificationFlags::P2SH | VerificationFlags::CHECKLOCKTIMEVERIFY;
+
+        let checker = CallbackTransactionSignatureChecker {
+            sighash: &missing_sighash,
+            lock_time: &n_lock_time.into(),
+            is_final,
+        };
+        let mut payload_l = ();
+        let mut payload_r = ();
+        let rust_stepper = DefaultStepEvaluator { flags, checker };
+        let stepper = ComparisonStepEvaluator {
+            eval_step_l: &rust_stepper,
+            eval_step_r: &rust_stepper,
+        };
+        let mut res = StepResults::initial(&mut payload_l, &mut payload_r);
+        let ret = RustInterpreter::verify(script_pub_key, script_sig, flags, &mut res, &stepper);
+
+        if res.diverging_result != None {
+            panic!("mismatched result: {:?}", res);
+        }
+        assert_eq!(ret, Err(Error::Ok(ScriptError::EvalFalse)));
+    }
+
+    proptest! {
+        // The stepwise comparison tests are significantly slower than the simple comparison tests,
+        // so run fewer iterations.
+        #![proptest_config(ProptestConfig {
+            cases: 2_000, .. ProptestConfig::default()
+        })]
+
+        #[test]
+        fn test_arbitrary_scripts(
+            lock_time in prop::num::u32::ANY,
+            is_final in prop::bool::ANY,
+            pub_key in prop::collection::vec(0..=0xffu8, 0..=OVERFLOW_SCRIPT_SIZE),
+            sig in prop::collection::vec(0..=0xffu8, 1..=OVERFLOW_SCRIPT_SIZE),
+            flags in prop::bits::u32::masked(VerificationFlags::all().bits()),
+        ) {
+            let checker = CallbackTransactionSignatureChecker {
+                sighash: &missing_sighash,
+                lock_time: &lock_time.into(),
+                is_final,
+            };
+            let flags = repair_flags(VerificationFlags::from_bits_truncate(flags));
+            let mut payload_l = ();
+            let mut payload_r = ();
+            let rust_stepper = DefaultStepEvaluator { flags, checker };
+            let stepper = ComparisonStepEvaluator {
+            eval_step_l: &rust_stepper,
+            eval_step_r: &rust_stepper,
+        };
+            let mut res = StepResults::initial(&mut payload_l, &mut payload_r);
+            let _ = RustInterpreter::verify(&pub_key[..], &sig[..], flags, &mut res, &stepper);
+
+            if res.diverging_result != None {
+                panic!("mismatched result: {:?}", res);
+            }
+        }
+
+        /// Similar to `test_arbitrary_scripts`, but ensures the `sig` only contains pushes.
+        #[test]
+        fn test_restricted_sig_scripts(
+            lock_time in prop::num::u32::ANY,
+            is_final in prop::bool::ANY,
+            pub_key in prop::collection::vec(0..=0xffu8, 0..=OVERFLOW_SCRIPT_SIZE),
+            sig in prop::collection::vec(0..=0x60u8, 0..=OVERFLOW_SCRIPT_SIZE),
+            flags in prop::bits::u32::masked(
+                // Don’t waste test cases on whether or not `SigPushOnly` is set.
+                (VerificationFlags::all() - VerificationFlags::SigPushOnly).bits()),
+        ) {
+            let lt = lock_time.into();
+            let checker = CallbackTransactionSignatureChecker {
+                sighash: &missing_sighash,
+                lock_time: &lt,
+                is_final,
+            };
+            let flags = repair_flags(VerificationFlags::from_bits_truncate(flags)) | VerificationFlags::SigPushOnly;
+            let mut payload_l = ();
+            let mut payload_r = ();
+            let rust_stepper = DefaultStepEvaluator { flags, checker };
+            let stepper = ComparisonStepEvaluator {
+            eval_step_l: &rust_stepper,
+            eval_step_r: &rust_stepper,
+        };
+            let mut res = StepResults::initial(&mut payload_l, &mut payload_r);
+            let _ = RustInterpreter::verify(&pub_key[..], &sig[..], flags, &mut res, &stepper);
+
+            if res.diverging_result != None {
+                panic!("mismatched result: {:?}", res);
+            }
+        }
     }
 }

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -162,8 +162,17 @@ pub struct StepwiseInterpreter<F>
 where
     F: StepFn,
 {
-    pub initial_payload: F::Payload,
-    pub stepper: F,
+    initial_payload: F::Payload,
+    stepper: F,
+}
+
+impl<F: StepFn> StepwiseInterpreter<F> {
+    pub fn new(initial_payload: F::Payload, stepper: F) -> Self {
+        StepwiseInterpreter {
+            initial_payload,
+            stepper,
+        }
+    }
 }
 
 pub fn rust_interpreter<C: SignatureChecker + Copy>(
@@ -298,12 +307,7 @@ mod tests {
                 identical_states,
                 diverging_result:
                     Some((
-                        Ok(State {
-                            stack,
-                            altstack,
-                            op_count: 2,
-                            vexec,
-                        }),
+                        Ok(state),
                         Err(ScriptError::ReadError {
                             expected_bytes: 1,
                             available_bytes: 0,
@@ -314,9 +318,10 @@ mod tests {
             } => {
                 assert!(
                     identical_states.len() == 6
-                        && stack.size() == 4
-                        && altstack.empty()
-                        && vexec.empty()
+                        && state.stack().size() == 4
+                        && state.altstack().empty()
+                        && state.op_count() == 2
+                        && state.vexec().empty()
                 );
             }
             _ => {


### PR DESCRIPTION
This extracts an `eval_step` from the Rust interpreter’s `eval_script` and adds tooling around that.

Most significantly, this adds a `StepFn` trait with implementations for
- standard Rust evaluation,
- “broken” evaluation (in the current example, it drops `OP_EQUAL` from scripts, to trigger divergences), and
- stepwise comparison of evaluators.

The latter will be used to do deep comparisons with the C++ interpreter when the `StepFn` impl for C++ is added in a future PR.