### PR TITLE
Eliminate `ScriptNum`

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -1,9 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use std::{
-    num::TryFromIntError,
-    ops::{Add, Neg, Sub},
-};
+use std::ops::{Add, Neg, Sub};
 
 use enum_primitive::FromPrimitive;
 
@@ -16,7 +13,7 @@ pub const MAX_SCRIPT_SIZE: usize = 10000;
 
 // Threshold for lock_time: below this value it is interpreted as block number,
 // otherwise as UNIX timestamp.
-pub const LOCKTIME_THRESHOLD: ScriptNum = ScriptNum(500000000); // Tue Nov  5 00:53:20 1985 UTC
+pub const LOCKTIME_THRESHOLD: i64 = 500000000; // Tue Nov  5 00:53:20 1985 UTC
 
 /** Script opcodes */
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
@@ -265,6 +262,115 @@ impl From<Operation> for u8 {
     }
 }
 
+const DEFAULT_MAX_NUM_SIZE: usize = 4;
+
+pub fn parse_num(
+    vch: &Vec<u8>,
+    require_minimal: bool,
+    max_num_size: Option<usize>,
+) -> Result<i64, ScriptNumError> {
+    match vch.last() {
+        None => Ok(0),
+        Some(vch_back) => {
+            let max_num_size = max_num_size.unwrap_or(DEFAULT_MAX_NUM_SIZE);
+            if vch.len() > max_num_size {
+                return Err(ScriptNumError::Overflow {
+                    max_num_size,
+                    actual: vch.len(),
+                });
+            }
+            if require_minimal {
+                // Check that the number is encoded with the minimum possible number of bytes.
+                //
+                // If the most-significant-byte - excluding the sign bit - is zero then we're not
+                // minimal. Note how this test also rejects the negative-zero encoding, 0x80.
+                if (vch_back & 0x7F) == 0 {
+                    // One exception: if there's more than one byte and the most significant bit of
+                    // the second-most-significant-byte is set then it would have conflicted with
+                    // the sign bit if one fewer byte were used, and so such encodings are minimal.
+                    // An example of this is +-255, which have minimal encodings [0xff, 0x00] and
+                    // [0xff, 0x80] respectively.
+                    if vch.len() <= 1 || (vch[vch.len() - 2] & 0x80) == 0 {
+                        return Err(ScriptNumError::NonMinimalEncoding);
+                    }
+                }
+            }
+
+            if *vch == vec![0, 0, 0, 0, 0, 0, 0, 128, 128] {
+                // Match the behaviour of the C++ code, which special-cased this encoding to avoid
+                // an undefined shift of a signed type by 64 bits.
+                return Ok(i64::MIN);
+            };
+
+            // Ensure defined behaviour (in Rust, left shift of `i64` by 64 bits is an arithmetic
+            // overflow that may panic or give an unspecified result). The above encoding of
+            // `i64::MIN` is the only allowed 9-byte encoding.
+            if vch.len() > 8 {
+                return Err(ScriptNumError::Overflow {
+                    max_num_size: 8,
+                    actual: vch.len(),
+                });
+            };
+
+            let mut result: i64 = 0;
+            for (i, vch_i) in vch.iter().enumerate() {
+                result |= i64::from(*vch_i) << (8 * i);
+            }
+
+            // If the input vector's most significant byte is 0x80, remove it from the result's msb
+            // and return a negative.
+            if vch_back & 0x80 != 0 {
+                return Ok(-(result & !(0x80 << (8 * (vch.len() - 1)))));
+            };
+
+            Ok(result)
+        }
+    }
+}
+
+pub fn serialize_num(value: i64) -> Vec<u8> {
+    if value == 0 {
+        return Vec::new();
+    }
+
+    if value == i64::MIN {
+        // The code below was based on buggy C++ code, that produced the "wrong" result for
+        // INT64_MIN. In that case we intentionally return the result that the C++ code as compiled
+        // for zcashd (with `-fwrapv`) originally produced on an x86_64 system.
+        return vec![0, 0, 0, 0, 0, 0, 0, 128, 128];
+    }
+
+    let mut result = Vec::new();
+    let neg = value < 0;
+    let mut absvalue = value.abs();
+
+    while absvalue != 0 {
+        result.push(
+            (absvalue & 0xff)
+                .try_into()
+                .unwrap_or_else(|_| unreachable!()),
+        );
+        absvalue >>= 8;
+    }
+
+    // - If the most significant byte is >= 0x80 and the value is positive, push a new zero-byte to
+    //   make the significant byte < 0x80 again.
+    // - If the most significant byte is >= 0x80 and the value is negative, push a new 0x80 byte
+    //   that will be popped off when converting to an integral.
+    // - If the most significant byte is < 0x80 and the value is negative, add 0x80 to it, since it
+    //   will be subtracted and interpreted as a negative when converting to an integral.
+
+    if result.last().map_or(true, |last| last & 0x80 != 0) {
+        result.push(if neg { 0x80 } else { 0 });
+    } else if neg {
+        if let Some(last) = result.last_mut() {
+            *last |= 0x80;
+        }
+    }
+
+    result
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct ScriptNum(i64);
 
@@ -272,149 +378,12 @@ impl ScriptNum {
     pub const ZERO: ScriptNum = ScriptNum(0);
     pub const ONE: ScriptNum = ScriptNum(1);
 
-    const DEFAULT_MAX_NUM_SIZE: usize = 4;
-
-    pub fn new(
-        vch: &Vec<u8>,
-        require_minimal: bool,
-        max_num_size: Option<usize>,
-    ) -> Result<Self, ScriptNumError> {
-        let max_num_size = max_num_size.unwrap_or(Self::DEFAULT_MAX_NUM_SIZE);
-        if vch.len() > max_num_size {
-            return Err(ScriptNumError::Overflow {
-                max_num_size,
-                actual: vch.len(),
-            });
-        }
-        if require_minimal && !vch.is_empty() {
-            // Check that the number is encoded with the minimum possible
-            // number of bytes.
-            //
-            // If the most-significant-byte - excluding the sign bit - is zero
-            // then we're not minimal. Note how this test also rejects the
-            // negative-zero encoding, 0x80.
-            if (vch.last().expect("not empty") & 0x7F) == 0 {
-                // One exception: if there's more than one byte and the most
-                // significant bit of the second-most-significant-byte is set
-                // then it would have conflicted with the sign bit if one
-                // fewer byte were used, and so such encodings are minimal.
-                // An example of this is +-255, which have minimal encodings
-                // [0xff, 0x00] and [0xff, 0x80] respectively.
-                if vch.len() <= 1 || (vch[vch.len() - 2] & 0x80) == 0 {
-                    return Err(ScriptNumError::NonMinimalEncoding);
-                }
-            }
-        }
-        Self::set_vch(vch).map(ScriptNum)
-    }
-
-    pub fn getint(&self) -> i32 {
-        if self.0 > i32::MAX.into() {
-            i32::MAX
-        } else if self.0 < i32::MIN.into() {
-            i32::MIN
-        } else {
-            self.0.try_into().unwrap()
-        }
+    pub fn new(vch: &Vec<u8>, require_minimal: bool) -> Result<Self, ScriptNumError> {
+        parse_num(vch, require_minimal, None).map(ScriptNum)
     }
 
     pub fn getvch(&self) -> Vec<u8> {
-        Self::serialize(&self.0)
-    }
-
-    fn set_vch(vch: &Vec<u8>) -> Result<i64, ScriptNumError> {
-        match vch.last() {
-            None => Ok(0),
-            Some(vch_back) => {
-                if *vch == vec![0, 0, 0, 0, 0, 0, 0, 128, 128] {
-                    // Match the behaviour of the C++ code, which special-cased this
-                    // encoding to avoid an undefined shift of a signed type by 64 bits.
-                    return Ok(i64::MIN);
-                };
-
-                // Ensure defined behaviour (in Rust, left shift of `i64` by 64 bits
-                // is an arithmetic overflow that may panic or give an unspecified
-                // result). The above encoding of `i64::MIN` is the only allowed
-                // 9-byte encoding.
-                if vch.len() > 8 {
-                    return Err(ScriptNumError::Overflow {
-                        max_num_size: 8,
-                        actual: vch.len(),
-                    });
-                };
-
-                let mut result: i64 = 0;
-                for (i, vch_i) in vch.iter().enumerate() {
-                    result |= i64::from(*vch_i) << (8 * i);
-                }
-
-                // If the input vector's most significant byte is 0x80, remove it from
-                // the result's msb and return a negative.
-                if vch_back & 0x80 != 0 {
-                    return Ok(-(result & !(0x80 << (8 * (vch.len() - 1)))));
-                };
-
-                Ok(result)
-            }
-        }
-    }
-
-    pub fn serialize(value: &i64) -> Vec<u8> {
-        if *value == 0 {
-            return Vec::new();
-        }
-
-        if *value == i64::MIN {
-            // The code below was based on buggy C++ code, that produced the
-            // "wrong" result for INT64_MIN. In that case we intentionally return
-            // the result that the C++ code as compiled for zcashd (with `-fwrapv`)
-            // originally produced on an x86_64 system.
-            return vec![0, 0, 0, 0, 0, 0, 0, 128, 128];
-        }
-
-        let mut result = Vec::new();
-        let neg = *value < 0;
-        let mut absvalue = value.unsigned_abs();
-
-        while absvalue != 0 {
-            result.push((absvalue & 0xff).try_into().expect("fits in u8"));
-            absvalue >>= 8;
-        }
-
-        // - If the most significant byte is >= 0x80 and the value is positive, push a
-        //   new zero-byte to make the significant byte < 0x80 again.
-        // - If the most significant byte is >= 0x80 and the value is negative, push a
-        //   new 0x80 byte that will be popped off when converting to an integral.
-        // - If the most significant byte is < 0x80 and the value is negative, add 0x80
-        //   to it, since it will be subtracted and interpreted as a negative when
-        //   converting to an integral.
-
-        let result_back = result.last_mut().expect("not empty");
-        if *result_back & 0x80 != 0 {
-            result.push(if neg { 0x80 } else { 0 });
-        } else if neg {
-            *result_back |= 0x80;
-        }
-
-        result
-    }
-}
-
-impl From<i32> for ScriptNum {
-    fn from(value: i32) -> Self {
-        ScriptNum(value.into())
-    }
-}
-
-impl From<u32> for ScriptNum {
-    fn from(value: u32) -> Self {
-        ScriptNum(value.into())
-    }
-}
-
-impl From<u8> for ScriptNum {
-    fn from(value: u8) -> Self {
-        ScriptNum(value.into())
+        serialize_num(self.0)
     }
 }
 
@@ -423,27 +392,6 @@ impl From<u8> for ScriptNum {
 impl From<bool> for ScriptNum {
     fn from(value: bool) -> Self {
         ScriptNum(value.into())
-    }
-}
-
-impl TryFrom<usize> for ScriptNum {
-    type Error = TryFromIntError;
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        value.try_into().map(ScriptNum)
-    }
-}
-
-impl TryFrom<ScriptNum> for u16 {
-    type Error = TryFromIntError;
-    fn try_from(value: ScriptNum) -> Result<Self, Self::Error> {
-        value.getint().try_into()
-    }
-}
-
-impl TryFrom<ScriptNum> for u8 {
-    type Error = TryFromIntError;
-    fn try_from(value: ScriptNum) -> Result<Self, Self::Error> {
-        value.getint().try_into()
     }
 }
 

--- a/src/script.rs
+++ b/src/script.rs
@@ -1,7 +1,5 @@
 #![allow(non_camel_case_types)]
 
-use std::ops::{Add, Neg, Sub};
-
 use enum_primitive::FromPrimitive;
 
 use super::script_error::*;
@@ -369,63 +367,6 @@ pub fn serialize_num(value: i64) -> Vec<u8> {
     }
 
     result
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub struct ScriptNum(i64);
-
-impl ScriptNum {
-    pub const ZERO: ScriptNum = ScriptNum(0);
-    pub const ONE: ScriptNum = ScriptNum(1);
-
-    pub fn new(vch: &Vec<u8>, require_minimal: bool) -> Result<Self, ScriptNumError> {
-        parse_num(vch, require_minimal, None).map(ScriptNum)
-    }
-
-    pub fn getvch(&self) -> Vec<u8> {
-        serialize_num(self.0)
-    }
-}
-
-/// TODO: This instance will be obsolete if we convert bool directly to a `Vec<u8>`, which is also
-///       more efficient.
-impl From<bool> for ScriptNum {
-    fn from(value: bool) -> Self {
-        ScriptNum(value.into())
-    }
-}
-
-impl Add for ScriptNum {
-    type Output = Self;
-
-    fn add(self, other: Self) -> Self {
-        Self(
-            self.0
-                .checked_add(other.0)
-                .expect("caller should avoid overflow"),
-        )
-    }
-}
-
-impl Sub for ScriptNum {
-    type Output = Self;
-
-    fn sub(self, other: Self) -> Self {
-        Self(
-            self.0
-                .checked_sub(other.0)
-                .expect("caller should avoid underflow"),
-        )
-    }
-}
-
-impl Neg for ScriptNum {
-    type Output = Self;
-
-    fn neg(self) -> Self {
-        assert!(self.0 != i64::MIN);
-        Self(-self.0)
-    }
 }
 
 /** Serialized script, used inside transaction inputs and outputs */


### PR DESCRIPTION
__NB__: I recommend reviewing commit-by-commit, and ignoring whitespace when reviewing the second commit.

`ScriptNum` was used one of three ways:
1. convert a Rust integer to a stack value,
2. load a stack value into Rust, xor
3. arithmetic on stack values.

Combining these into one interface added extra complexity. For example, `getint()` would clamp the value to `i32` range, but that range could only be violated if arithmetic was performed on `ScriptNum`s, and `getint()` was never used on the result of arithmetic.

This extracts `parse_num` and `serialize_num` and adds a number of small functions that encapsulate the different arithemetic operations. The above patterns have changed in the following ways:
1. `ScriptNum::from(_).getvch()` is now `serialize_num(_)`, and
2. `ScriptNum::new(_).and_then(_.getint())` is now `parse_num(_)`,
3. `ScriptNum::new(_)` … `getvch()` uses `binop(_, _)` and friends.

Because only `i32` values are read from the stack, but `i64` results are pushed back onto the stack[^1], the arithmetic operations that exist can’t possibly hit the various bounds that were checked on `ScriptNum` operations, so they were removed.

[^1]: This does mean that a script like `[0, 1, i32::MAX, OP_ADD, OP_ADD]` will fail with `ScriptNumError::Overflow`[^2] when the second `OP_ADD` tries to read `i32::MAX+1` as its second argument, but them’s the semantics we were given.

[^2]: Even worse, in the C++ impl, this simply comes back as `UnknownError`.

As part of the above work, this introduces `cast_from_bool`, which is then used to replace all instances of `VCH_TRUE`/`FALSE`.