### PR TITLE
C++ stepwise comparison

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,7 @@ impl std::error::Error for Error {}
 // to pull a newer version, so this silences the deprecation on that job.
 #[allow(deprecated)]
 fn bindgen_headers() -> Result<()> {
-    println!("cargo:rerun-if-changed=depend/zcash/src/script/zcash_script.h");
+    println!("cargo:rerun-if-changed=depend/zcash/src/script/zcash_script.cpp");
 
     let bindings = bindgen::Builder::default()
         .header("depend/zcash/src/script/zcash_script.h")

--- a/depend/zcash/src/script/interpreter.cpp
+++ b/depend/zcash/src/script/interpreter.cpp
@@ -240,470 +240,493 @@ bool EvalScript(
     uint32_t consensusBranchId,
     ScriptError* serror)
 {
-    static const CScriptNum bnZero(0);
-    static const CScriptNum bnOne(1);
-    static const CScriptNum bnFalse(0);
-    static const CScriptNum bnTrue(1);
-    static const valtype vchFalse(0);
-    static const valtype vchZero(0);
-    static const valtype vchTrue(1, 1);
-
     CScript::const_iterator pc = script.begin();
     CScript::const_iterator pend = script.end();
-    opcodetype opcode;
-    valtype vchPushValue;
-    vector<bool> vfExec;
-    vector<valtype> altstack;
     set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
     if (script.size() > MAX_SCRIPT_SIZE)
         return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
-    int nOpCount = 0;
-    bool fRequireMinimal = (flags & SCRIPT_VERIFY_MINIMALDATA) != 0;
+    State state = State{stack};
 
     try
     {
         while (pc < pend)
+            if (!EvalStep(state, script, pc, flags, checker, consensusBranchId, serror))
+                return false;
+        stack = state.stack;
+    }
+    catch (...)
+    {
+        return set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
+    }
+
+    if (!state.vfExec.empty())
+        return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+
+    return set_success(serror);
+}
+
+static const CScriptNum bnZero(0);
+static const CScriptNum bnOne(1);
+static const valtype vchFalse(0);
+static const valtype vchTrue(1, 1);
+
+bool EvalStep(
+    struct State& state,
+    const CScript& script,
+    CScript::const_iterator& pc,
+    unsigned int flags,
+    const BaseSignatureChecker& checker,
+    uint32_t consensusBranchId,
+    ScriptError* serror)
+{
+    std::vector<std::vector<unsigned char> >& stack = state.stack;
+    std::vector<std::vector<unsigned char> >& altstack = state.altstack;
+    opcodetype opcode;
+    valtype vchPushValue;
+    std::vector<bool>& vfExec = state.vfExec;
+    int& nOpCount = state.nOpCount;
+    bool fRequireMinimal = (flags & SCRIPT_VERIFY_MINIMALDATA) != 0;
+
+    bool fExec = !count(vfExec.begin(), vfExec.end(), false);
+
+    //
+    // Read instruction
+    //
+    if (!script.GetOp(pc, opcode, vchPushValue))
+        return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
+    if (vchPushValue.size() > MAX_SCRIPT_ELEMENT_SIZE)
+        return set_error(serror, SCRIPT_ERR_PUSH_SIZE);
+
+    // Note how OP_RESERVED does not count towards the opcode limit.
+    if (opcode > OP_16 && ++nOpCount > 201)
+        return set_error(serror, SCRIPT_ERR_OP_COUNT);
+
+    if (opcode == OP_CAT ||
+        opcode == OP_SUBSTR ||
+        opcode == OP_LEFT ||
+        opcode == OP_RIGHT ||
+        opcode == OP_INVERT ||
+        opcode == OP_AND ||
+        opcode == OP_OR ||
+        opcode == OP_XOR ||
+        opcode == OP_2MUL ||
+        opcode == OP_2DIV ||
+        opcode == OP_MUL ||
+        opcode == OP_DIV ||
+        opcode == OP_MOD ||
+        opcode == OP_LSHIFT ||
+        opcode == OP_RSHIFT ||
+        opcode == OP_CODESEPARATOR)
+        return set_error(serror, SCRIPT_ERR_DISABLED_OPCODE); // Disabled opcodes.
+
+    if (fExec && 0 <= opcode && opcode <= OP_PUSHDATA4) {
+        if (fRequireMinimal && !CheckMinimalPush(vchPushValue, opcode)) {
+            return set_error(serror, SCRIPT_ERR_MINIMALDATA);
+        }
+        stack.push_back(vchPushValue);
+    } else if (fExec || (OP_IF <= opcode && opcode <= OP_ENDIF))
+        switch (opcode)
         {
-            bool fExec = !count(vfExec.begin(), vfExec.end(), false);
-
             //
-            // Read instruction
+            // Push value
             //
-            if (!script.GetOp(pc, opcode, vchPushValue))
-                return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
-            if (vchPushValue.size() > MAX_SCRIPT_ELEMENT_SIZE)
-                return set_error(serror, SCRIPT_ERR_PUSH_SIZE);
-
-            // Note how OP_RESERVED does not count towards the opcode limit.
-            if (opcode > OP_16 && ++nOpCount > 201)
-                return set_error(serror, SCRIPT_ERR_OP_COUNT);
-
-            if (opcode == OP_CAT ||
-                opcode == OP_SUBSTR ||
-                opcode == OP_LEFT ||
-                opcode == OP_RIGHT ||
-                opcode == OP_INVERT ||
-                opcode == OP_AND ||
-                opcode == OP_OR ||
-                opcode == OP_XOR ||
-                opcode == OP_2MUL ||
-                opcode == OP_2DIV ||
-                opcode == OP_MUL ||
-                opcode == OP_DIV ||
-                opcode == OP_MOD ||
-                opcode == OP_LSHIFT ||
-                opcode == OP_RSHIFT ||
-                opcode == OP_CODESEPARATOR)
-                return set_error(serror, SCRIPT_ERR_DISABLED_OPCODE); // Disabled opcodes.
-
-            if (fExec && 0 <= opcode && opcode <= OP_PUSHDATA4) {
-                if (fRequireMinimal && !CheckMinimalPush(vchPushValue, opcode)) {
-                    return set_error(serror, SCRIPT_ERR_MINIMALDATA);
-                }
-                stack.push_back(vchPushValue);
-            } else if (fExec || (OP_IF <= opcode && opcode <= OP_ENDIF))
-            switch (opcode)
+            case OP_1NEGATE:
+            case OP_1:
+            case OP_2:
+            case OP_3:
+            case OP_4:
+            case OP_5:
+            case OP_6:
+            case OP_7:
+            case OP_8:
+            case OP_9:
+            case OP_10:
+            case OP_11:
+            case OP_12:
+            case OP_13:
+            case OP_14:
+            case OP_15:
+            case OP_16:
             {
-                //
-                // Push value
-                //
-                case OP_1NEGATE:
-                case OP_1:
-                case OP_2:
-                case OP_3:
-                case OP_4:
-                case OP_5:
-                case OP_6:
-                case OP_7:
-                case OP_8:
-                case OP_9:
-                case OP_10:
-                case OP_11:
-                case OP_12:
-                case OP_13:
-                case OP_14:
-                case OP_15:
-                case OP_16:
-                {
-                    // ( -- value)
-                    CScriptNum bn((int)opcode - (int)(OP_1 - 1));
-                    stack.push_back(bn.getvch());
-                    // The result of these opcodes should always be the minimal way to push the data
-                    // they push, so no need for a CheckMinimalPush here.
-                }
+                // ( -- value)
+                CScriptNum bn((int)opcode - (int)(OP_1 - 1));
+                stack.push_back(bn.getvch());
+                // The result of these opcodes should always be the minimal way to push the data
+                // they push, so no need for a CheckMinimalPush here.
+            }
+            break;
+
+
+            //
+            // Control
+            //
+            case OP_NOP:
                 break;
 
-
-                //
-                // Control
-                //
-                case OP_NOP:
-                    break;
-
-                case OP_CHECKLOCKTIMEVERIFY:
-                {
-                    if (!(flags & SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY)) {
-                        // not enabled; treat as a NOP2
-                        if (flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS) {
-                            return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS);
-                        }
-                        break;
-                    }
-
-                    if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-
-                    // Note that elsewhere numeric opcodes are limited to
-                    // operands in the range -2**31+1 to 2**31-1, however it is
-                    // legal for opcodes to produce results exceeding that
-                    // range. This limitation is implemented by CScriptNum's
-                    // default 4-byte limit.
-                    //
-                    // If we kept to that limit we'd have a year 2038 problem,
-                    // even though the nLockTime field in transactions
-                    // themselves is uint32 which only becomes meaningless
-                    // after the year 2106.
-                    //
-                    // Thus as a special case we tell CScriptNum to accept up
-                    // to 5-byte bignums, which are good until 2**39-1, well
-                    // beyond the 2**32-1 limit of the nLockTime field itself.
-                    const CScriptNum nLockTime(stacktop(-1), fRequireMinimal, 5);
-
-                    // In the rare event that the argument may be < 0 due to
-                    // some arithmetic being done first, you can always use
-                    // 0 MAX CHECKLOCKTIMEVERIFY.
-                    if (nLockTime < 0)
-                        return set_error(serror, SCRIPT_ERR_NEGATIVE_LOCKTIME);
-
-                    // Actually compare the specified lock time with the transaction.
-                    if (!checker.CheckLockTime(nLockTime))
-                        return set_error(serror, SCRIPT_ERR_UNSATISFIED_LOCKTIME);
-
-                    break;
-                }
-
-                case OP_NOP1: case OP_NOP3: case OP_NOP4: case OP_NOP5:
-                case OP_NOP6: case OP_NOP7: case OP_NOP8: case OP_NOP9: case OP_NOP10:
-                {
-                    if (flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS)
+            case OP_CHECKLOCKTIMEVERIFY:
+            {
+                if (!(flags & SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY)) {
+                    // not enabled; treat as a NOP2
+                    if (flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS) {
                         return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS);
-                }
-                break;
-
-                case OP_IF:
-                case OP_NOTIF:
-                {
-                    // <expression> if [statements] [else [statements]] endif
-                    bool fValue = false;
-                    if (fExec)
-                    {
-                        if (stack.size() < 1)
-                            return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
-                        valtype& vch = stacktop(-1);
-                        fValue = CastToBool(vch);
-                        if (opcode == OP_NOTIF)
-                            fValue = !fValue;
-                        popstack(stack);
                     }
-                    vfExec.push_back(fValue);
+                    break;
                 }
-                break;
 
-                case OP_ELSE:
-                {
-                    if (vfExec.empty())
-                        return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
-                    vfExec.back() = !vfExec.back();
-                }
-                break;
+                if (stack.size() < 1)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
 
-                case OP_ENDIF:
-                {
-                    if (vfExec.empty())
-                        return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
-                    vfExec.pop_back();
-                }
-                break;
+                // Note that elsewhere numeric opcodes are limited to
+                // operands in the range -2**31+1 to 2**31-1, however it is
+                // legal for opcodes to produce results exceeding that
+                // range. This limitation is implemented by CScriptNum's
+                // default 4-byte limit.
+                //
+                // If we kept to that limit we'd have a year 2038 problem,
+                // even though the nLockTime field in transactions
+                // themselves is uint32 which only becomes meaningless
+                // after the year 2106.
+                //
+                // Thus as a special case we tell CScriptNum to accept up
+                // to 5-byte bignums, which are good until 2**39-1, well
+                // beyond the 2**32-1 limit of the nLockTime field itself.
+                const CScriptNum nLockTime(stacktop(-1), fRequireMinimal, 5);
 
-                case OP_VERIFY:
+                // In the rare event that the argument may be < 0 due to
+                // some arithmetic being done first, you can always use
+                // 0 MAX CHECKLOCKTIMEVERIFY.
+                if (nLockTime < 0)
+                    return set_error(serror, SCRIPT_ERR_NEGATIVE_LOCKTIME);
+
+                // Actually compare the specified lock time with the transaction.
+                if (!checker.CheckLockTime(nLockTime))
+                    return set_error(serror, SCRIPT_ERR_UNSATISFIED_LOCKTIME);
+
+                break;
+            }
+
+            case OP_NOP1: case OP_NOP3: case OP_NOP4: case OP_NOP5:
+            case OP_NOP6: case OP_NOP7: case OP_NOP8: case OP_NOP9: case OP_NOP10:
+            {
+                if (flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS)
+                    return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS);
+            }
+            break;
+
+            case OP_IF:
+            case OP_NOTIF:
+            {
+                // <expression> if [statements] [else [statements]] endif
+                bool fValue = false;
+                if (fExec)
                 {
-                    // (true -- ) or
-                    // (false -- false) and return
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    bool fValue = CastToBool(stacktop(-1));
-                    if (fValue)
+                        return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+                    valtype& vch = stacktop(-1);
+                    fValue = CastToBool(vch);
+                    if (opcode == OP_NOTIF)
+                        fValue = !fValue;
+                    popstack(stack);
+                }
+                vfExec.push_back(fValue);
+            }
+            break;
+
+            case OP_ELSE:
+            {
+                if (vfExec.empty())
+                    return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+                vfExec.back() = !vfExec.back();
+            }
+            break;
+
+            case OP_ENDIF:
+            {
+                if (vfExec.empty())
+                    return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+                vfExec.pop_back();
+            }
+            break;
+
+            case OP_VERIFY:
+            {
+                // (true -- ) or
+                // (false -- false) and return
+                if (stack.size() < 1)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                bool fValue = CastToBool(stacktop(-1));
+                if (fValue)
+                    popstack(stack);
+                else
+                    return set_error(serror, SCRIPT_ERR_VERIFY);
+            }
+            break;
+
+            case OP_RETURN:
+            {
+                return set_error(serror, SCRIPT_ERR_OP_RETURN);
+            }
+            break;
+
+
+            //
+            // Stack ops
+            //
+            case OP_TOALTSTACK:
+            {
+                if (stack.size() < 1)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                altstack.push_back(stacktop(-1));
+                popstack(stack);
+            }
+            break;
+
+            case OP_FROMALTSTACK:
+            {
+                if (altstack.size() < 1)
+                    return set_error(serror, SCRIPT_ERR_INVALID_ALTSTACK_OPERATION);
+                stack.push_back(altstacktop(-1));
+                popstack(altstack);
+            }
+            break;
+
+            case OP_2DROP:
+            {
+                // (x1 x2 -- )
+                if (stack.size() < 2)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                popstack(stack);
+                popstack(stack);
+            }
+            break;
+
+            case OP_2DUP:
+            {
+                // (x1 x2 -- x1 x2 x1 x2)
+                if (stack.size() < 2)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                valtype vch1 = stacktop(-2);
+                valtype vch2 = stacktop(-1);
+                stack.push_back(vch1);
+                stack.push_back(vch2);
+            }
+            break;
+
+            case OP_3DUP:
+            {
+                // (x1 x2 x3 -- x1 x2 x3 x1 x2 x3)
+                if (stack.size() < 3)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                valtype vch1 = stacktop(-3);
+                valtype vch2 = stacktop(-2);
+                valtype vch3 = stacktop(-1);
+                stack.push_back(vch1);
+                stack.push_back(vch2);
+                stack.push_back(vch3);
+            }
+            break;
+
+            case OP_2OVER:
+            {
+                // (x1 x2 x3 x4 -- x1 x2 x3 x4 x1 x2)
+                if (stack.size() < 4)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                valtype vch1 = stacktop(-4);
+                valtype vch2 = stacktop(-3);
+                stack.push_back(vch1);
+                stack.push_back(vch2);
+            }
+            break;
+
+            case OP_2ROT:
+            {
+                // (x1 x2 x3 x4 x5 x6 -- x3 x4 x5 x6 x1 x2)
+                if (stack.size() < 6)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                valtype vch1 = stacktop(-6);
+                valtype vch2 = stacktop(-5);
+                stack.erase(stack.end()-6, stack.end()-4);
+                stack.push_back(vch1);
+                stack.push_back(vch2);
+            }
+            break;
+
+            case OP_2SWAP:
+            {
+                // (x1 x2 x3 x4 -- x3 x4 x1 x2)
+                if (stack.size() < 4)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                swap(stacktop(-4), stacktop(-2));
+                swap(stacktop(-3), stacktop(-1));
+            }
+            break;
+
+            case OP_IFDUP:
+            {
+                // (x - 0 | x x)
+                if (stack.size() < 1)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                valtype vch = stacktop(-1);
+                if (CastToBool(vch))
+                    stack.push_back(vch);
+            }
+            break;
+
+            case OP_DEPTH:
+            {
+                // -- stacksize
+                CScriptNum bn(stack.size());
+                stack.push_back(bn.getvch());
+            }
+            break;
+
+            case OP_DROP:
+            {
+                // (x -- )
+                if (stack.size() < 1)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                popstack(stack);
+            }
+            break;
+
+            case OP_DUP:
+            {
+                // (x -- x x)
+                if (stack.size() < 1)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                valtype vch = stacktop(-1);
+                stack.push_back(vch);
+            }
+            break;
+
+            case OP_NIP:
+            {
+                // (x1 x2 -- x2)
+                if (stack.size() < 2)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                stack.erase(stack.end() - 2);
+            }
+            break;
+
+            case OP_OVER:
+            {
+                // (x1 x2 -- x1 x2 x1)
+                if (stack.size() < 2)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                valtype vch = stacktop(-2);
+                stack.push_back(vch);
+            }
+            break;
+
+            case OP_PICK:
+            case OP_ROLL:
+            {
+                // (xn ... x2 x1 x0 n - xn ... x2 x1 x0 xn)
+                // (xn ... x2 x1 x0 n - ... x2 x1 x0 xn)
+                if (stack.size() < 2)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                int n = CScriptNum(stacktop(-1), fRequireMinimal).getint();
+                popstack(stack);
+                if (n < 0 || n >= (int)stack.size())
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                valtype vch = stacktop(-n-1);
+                if (opcode == OP_ROLL)
+                    stack.erase(stack.end()-n-1);
+                stack.push_back(vch);
+            }
+            break;
+
+            case OP_ROT:
+            {
+                // (x1 x2 x3 -- x2 x3 x1)
+                //  x2 x1 x3  after first swap
+                //  x2 x3 x1  after second swap
+                if (stack.size() < 3)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                swap(stacktop(-3), stacktop(-2));
+                swap(stacktop(-2), stacktop(-1));
+            }
+            break;
+
+            case OP_SWAP:
+            {
+                // (x1 x2 -- x2 x1)
+                if (stack.size() < 2)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                swap(stacktop(-2), stacktop(-1));
+            }
+            break;
+
+            case OP_TUCK:
+            {
+                // (x1 x2 -- x2 x1 x2)
+                if (stack.size() < 2)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                valtype vch = stacktop(-1);
+                stack.insert(stack.end()-2, vch);
+            }
+            break;
+
+
+            case OP_SIZE:
+            {
+                // (in -- in size)
+                if (stack.size() < 1)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                CScriptNum bn(stacktop(-1).size());
+                stack.push_back(bn.getvch());
+            }
+            break;
+
+
+            //
+            // Bitwise logic
+            //
+            case OP_EQUAL:
+            case OP_EQUALVERIFY:
+                //case OP_NOTEQUAL: // use OP_NUMNOTEQUAL
+            {
+                // (x1 x2 - bool)
+                if (stack.size() < 2)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                valtype& vch1 = stacktop(-2);
+                valtype& vch2 = stacktop(-1);
+                bool fEqual = (vch1 == vch2);
+                // OP_NOTEQUAL is disabled because it would be too easy to say
+                // something like n != 1 and have some wiseguy pass in 1 with extra
+                // zero bytes after it (numerically, 0x01 == 0x0001 == 0x000001)
+                //if (opcode == OP_NOTEQUAL)
+                //    fEqual = !fEqual;
+                popstack(stack);
+                popstack(stack);
+                stack.push_back(fEqual ? vchTrue : vchFalse);
+                if (opcode == OP_EQUALVERIFY)
+                {
+                    if (fEqual)
                         popstack(stack);
                     else
-                        return set_error(serror, SCRIPT_ERR_VERIFY);
+                        return set_error(serror, SCRIPT_ERR_EQUALVERIFY);
                 }
-                break;
+            }
+            break;
 
-                case OP_RETURN:
+
+            //
+            // Numeric
+            //
+            case OP_1ADD:
+            case OP_1SUB:
+            case OP_NEGATE:
+            case OP_ABS:
+            case OP_NOT:
+            case OP_0NOTEQUAL:
+            {
+                // (in -- out)
+                if (stack.size() < 1)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                CScriptNum bn(stacktop(-1), fRequireMinimal);
+                switch (opcode)
                 {
-                    return set_error(serror, SCRIPT_ERR_OP_RETURN);
-                }
-                break;
-
-
-                //
-                // Stack ops
-                //
-                case OP_TOALTSTACK:
-                {
-                    if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    altstack.push_back(stacktop(-1));
-                    popstack(stack);
-                }
-                break;
-
-                case OP_FROMALTSTACK:
-                {
-                    if (altstack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_ALTSTACK_OPERATION);
-                    stack.push_back(altstacktop(-1));
-                    popstack(altstack);
-                }
-                break;
-
-                case OP_2DROP:
-                {
-                    // (x1 x2 -- )
-                    if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    popstack(stack);
-                    popstack(stack);
-                }
-                break;
-
-                case OP_2DUP:
-                {
-                    // (x1 x2 -- x1 x2 x1 x2)
-                    if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    valtype vch1 = stacktop(-2);
-                    valtype vch2 = stacktop(-1);
-                    stack.push_back(vch1);
-                    stack.push_back(vch2);
-                }
-                break;
-
-                case OP_3DUP:
-                {
-                    // (x1 x2 x3 -- x1 x2 x3 x1 x2 x3)
-                    if (stack.size() < 3)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    valtype vch1 = stacktop(-3);
-                    valtype vch2 = stacktop(-2);
-                    valtype vch3 = stacktop(-1);
-                    stack.push_back(vch1);
-                    stack.push_back(vch2);
-                    stack.push_back(vch3);
-                }
-                break;
-
-                case OP_2OVER:
-                {
-                    // (x1 x2 x3 x4 -- x1 x2 x3 x4 x1 x2)
-                    if (stack.size() < 4)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    valtype vch1 = stacktop(-4);
-                    valtype vch2 = stacktop(-3);
-                    stack.push_back(vch1);
-                    stack.push_back(vch2);
-                }
-                break;
-
-                case OP_2ROT:
-                {
-                    // (x1 x2 x3 x4 x5 x6 -- x3 x4 x5 x6 x1 x2)
-                    if (stack.size() < 6)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    valtype vch1 = stacktop(-6);
-                    valtype vch2 = stacktop(-5);
-                    stack.erase(stack.end()-6, stack.end()-4);
-                    stack.push_back(vch1);
-                    stack.push_back(vch2);
-                }
-                break;
-
-                case OP_2SWAP:
-                {
-                    // (x1 x2 x3 x4 -- x3 x4 x1 x2)
-                    if (stack.size() < 4)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    swap(stacktop(-4), stacktop(-2));
-                    swap(stacktop(-3), stacktop(-1));
-                }
-                break;
-
-                case OP_IFDUP:
-                {
-                    // (x - 0 | x x)
-                    if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    valtype vch = stacktop(-1);
-                    if (CastToBool(vch))
-                        stack.push_back(vch);
-                }
-                break;
-
-                case OP_DEPTH:
-                {
-                    // -- stacksize
-                    CScriptNum bn(stack.size());
-                    stack.push_back(bn.getvch());
-                }
-                break;
-
-                case OP_DROP:
-                {
-                    // (x -- )
-                    if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    popstack(stack);
-                }
-                break;
-
-                case OP_DUP:
-                {
-                    // (x -- x x)
-                    if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    valtype vch = stacktop(-1);
-                    stack.push_back(vch);
-                }
-                break;
-
-                case OP_NIP:
-                {
-                    // (x1 x2 -- x2)
-                    if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    stack.erase(stack.end() - 2);
-                }
-                break;
-
-                case OP_OVER:
-                {
-                    // (x1 x2 -- x1 x2 x1)
-                    if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    valtype vch = stacktop(-2);
-                    stack.push_back(vch);
-                }
-                break;
-
-                case OP_PICK:
-                case OP_ROLL:
-                {
-                    // (xn ... x2 x1 x0 n - xn ... x2 x1 x0 xn)
-                    // (xn ... x2 x1 x0 n - ... x2 x1 x0 xn)
-                    if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    int n = CScriptNum(stacktop(-1), fRequireMinimal).getint();
-                    popstack(stack);
-                    if (n < 0 || n >= (int)stack.size())
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    valtype vch = stacktop(-n-1);
-                    if (opcode == OP_ROLL)
-                        stack.erase(stack.end()-n-1);
-                    stack.push_back(vch);
-                }
-                break;
-
-                case OP_ROT:
-                {
-                    // (x1 x2 x3 -- x2 x3 x1)
-                    //  x2 x1 x3  after first swap
-                    //  x2 x3 x1  after second swap
-                    if (stack.size() < 3)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    swap(stacktop(-3), stacktop(-2));
-                    swap(stacktop(-2), stacktop(-1));
-                }
-                break;
-
-                case OP_SWAP:
-                {
-                    // (x1 x2 -- x2 x1)
-                    if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    swap(stacktop(-2), stacktop(-1));
-                }
-                break;
-
-                case OP_TUCK:
-                {
-                    // (x1 x2 -- x2 x1 x2)
-                    if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    valtype vch = stacktop(-1);
-                    stack.insert(stack.end()-2, vch);
-                }
-                break;
-
-
-                case OP_SIZE:
-                {
-                    // (in -- in size)
-                    if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    CScriptNum bn(stacktop(-1).size());
-                    stack.push_back(bn.getvch());
-                }
-                break;
-
-
-                //
-                // Bitwise logic
-                //
-                case OP_EQUAL:
-                case OP_EQUALVERIFY:
-                //case OP_NOTEQUAL: // use OP_NUMNOTEQUAL
-                {
-                    // (x1 x2 - bool)
-                    if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    valtype& vch1 = stacktop(-2);
-                    valtype& vch2 = stacktop(-1);
-                    bool fEqual = (vch1 == vch2);
-                    // OP_NOTEQUAL is disabled because it would be too easy to say
-                    // something like n != 1 and have some wiseguy pass in 1 with extra
-                    // zero bytes after it (numerically, 0x01 == 0x0001 == 0x000001)
-                    //if (opcode == OP_NOTEQUAL)
-                    //    fEqual = !fEqual;
-                    popstack(stack);
-                    popstack(stack);
-                    stack.push_back(fEqual ? vchTrue : vchFalse);
-                    if (opcode == OP_EQUALVERIFY)
-                    {
-                        if (fEqual)
-                            popstack(stack);
-                        else
-                            return set_error(serror, SCRIPT_ERR_EQUALVERIFY);
-                    }
-                }
-                break;
-
-
-                //
-                // Numeric
-                //
-                case OP_1ADD:
-                case OP_1SUB:
-                case OP_NEGATE:
-                case OP_ABS:
-                case OP_NOT:
-                case OP_0NOTEQUAL:
-                {
-                    // (in -- out)
-                    if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    CScriptNum bn(stacktop(-1), fRequireMinimal);
-                    switch (opcode)
-                    {
                     case OP_1ADD:       bn += bnOne; break;
                     case OP_1SUB:       bn -= bnOne; break;
                     case OP_NEGATE:     bn = -bn; break;
@@ -711,34 +734,34 @@ bool EvalScript(
                     case OP_NOT:        bn = (bn == bnZero); break;
                     case OP_0NOTEQUAL:  bn = (bn != bnZero); break;
                     default:            assert(!"invalid opcode"); break;
-                    }
-                    popstack(stack);
-                    stack.push_back(bn.getvch());
                 }
-                break;
+                popstack(stack);
+                stack.push_back(bn.getvch());
+            }
+            break;
 
-                case OP_ADD:
-                case OP_SUB:
-                case OP_BOOLAND:
-                case OP_BOOLOR:
-                case OP_NUMEQUAL:
-                case OP_NUMEQUALVERIFY:
-                case OP_NUMNOTEQUAL:
-                case OP_LESSTHAN:
-                case OP_GREATERTHAN:
-                case OP_LESSTHANOREQUAL:
-                case OP_GREATERTHANOREQUAL:
-                case OP_MIN:
-                case OP_MAX:
+            case OP_ADD:
+            case OP_SUB:
+            case OP_BOOLAND:
+            case OP_BOOLOR:
+            case OP_NUMEQUAL:
+            case OP_NUMEQUALVERIFY:
+            case OP_NUMNOTEQUAL:
+            case OP_LESSTHAN:
+            case OP_GREATERTHAN:
+            case OP_LESSTHANOREQUAL:
+            case OP_GREATERTHANOREQUAL:
+            case OP_MIN:
+            case OP_MAX:
+            {
+                // (x1 x2 -- out)
+                if (stack.size() < 2)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                CScriptNum bn1(stacktop(-2), fRequireMinimal);
+                CScriptNum bn2(stacktop(-1), fRequireMinimal);
+                CScriptNum bn(0);
+                switch (opcode)
                 {
-                    // (x1 x2 -- out)
-                    if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    CScriptNum bn1(stacktop(-2), fRequireMinimal);
-                    CScriptNum bn2(stacktop(-1), fRequireMinimal);
-                    CScriptNum bn(0);
-                    switch (opcode)
-                    {
                     case OP_ADD:
                         bn = bn1 + bn2;
                         break;
@@ -759,201 +782,192 @@ bool EvalScript(
                     case OP_MIN:                 bn = (bn1 < bn2 ? bn1 : bn2); break;
                     case OP_MAX:                 bn = (bn1 > bn2 ? bn1 : bn2); break;
                     default:                     assert(!"invalid opcode"); break;
-                    }
-                    popstack(stack);
-                    popstack(stack);
-                    stack.push_back(bn.getvch());
-
-                    if (opcode == OP_NUMEQUALVERIFY)
-                    {
-                        if (CastToBool(stacktop(-1)))
-                            popstack(stack);
-                        else
-                            return set_error(serror, SCRIPT_ERR_NUMEQUALVERIFY);
-                    }
                 }
-                break;
+                popstack(stack);
+                popstack(stack);
+                stack.push_back(bn.getvch());
 
-                case OP_WITHIN:
+                if (opcode == OP_NUMEQUALVERIFY)
                 {
-                    // (x min max -- out)
-                    if (stack.size() < 3)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    CScriptNum bn1(stacktop(-3), fRequireMinimal);
-                    CScriptNum bn2(stacktop(-2), fRequireMinimal);
-                    CScriptNum bn3(stacktop(-1), fRequireMinimal);
-                    bool fValue = (bn2 <= bn1 && bn1 < bn3);
-                    popstack(stack);
-                    popstack(stack);
-                    popstack(stack);
-                    stack.push_back(fValue ? vchTrue : vchFalse);
+                    if (CastToBool(stacktop(-1)))
+                        popstack(stack);
+                    else
+                        return set_error(serror, SCRIPT_ERR_NUMEQUALVERIFY);
                 }
-                break;
+            }
+            break;
+
+            case OP_WITHIN:
+            {
+                // (x min max -- out)
+                if (stack.size() < 3)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                CScriptNum bn1(stacktop(-3), fRequireMinimal);
+                CScriptNum bn2(stacktop(-2), fRequireMinimal);
+                CScriptNum bn3(stacktop(-1), fRequireMinimal);
+                bool fValue = (bn2 <= bn1 && bn1 < bn3);
+                popstack(stack);
+                popstack(stack);
+                popstack(stack);
+                stack.push_back(fValue ? vchTrue : vchFalse);
+            }
+            break;
 
 
-                //
-                // Crypto
-                //
-                case OP_RIPEMD160:
-                case OP_SHA1:
-                case OP_SHA256:
-                case OP_HASH160:
-                case OP_HASH256:
-                {
-                    // (in -- hash)
-                    if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    valtype& vch = stacktop(-1);
-                    valtype vchHash((opcode == OP_RIPEMD160 || opcode == OP_SHA1 || opcode == OP_HASH160) ? 20 : 32);
-                    if (opcode == OP_RIPEMD160)
-                        CRIPEMD160().Write(begin_ptr(vch), vch.size()).Finalize(begin_ptr(vchHash));
-                    else if (opcode == OP_SHA1)
-                        CSHA1().Write(begin_ptr(vch), vch.size()).Finalize(begin_ptr(vchHash));
-                    else if (opcode == OP_SHA256)
-                        CSHA256().Write(begin_ptr(vch), vch.size()).Finalize(begin_ptr(vchHash));
-                    else if (opcode == OP_HASH160)
-                        CHash160().Write(begin_ptr(vch), vch.size()).Finalize(begin_ptr(vchHash));
-                    else if (opcode == OP_HASH256)
-                        CHash256().Write(begin_ptr(vch), vch.size()).Finalize(begin_ptr(vchHash));
-                    popstack(stack);
-                    stack.push_back(vchHash);
+            //
+            // Crypto
+            //
+            case OP_RIPEMD160:
+            case OP_SHA1:
+            case OP_SHA256:
+            case OP_HASH160:
+            case OP_HASH256:
+            {
+                // (in -- hash)
+                if (stack.size() < 1)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                valtype& vch = stacktop(-1);
+                valtype vchHash((opcode == OP_RIPEMD160 || opcode == OP_SHA1 || opcode == OP_HASH160) ? 20 : 32);
+                if (opcode == OP_RIPEMD160)
+                    CRIPEMD160().Write(begin_ptr(vch), vch.size()).Finalize(begin_ptr(vchHash));
+                else if (opcode == OP_SHA1)
+                    CSHA1().Write(begin_ptr(vch), vch.size()).Finalize(begin_ptr(vchHash));
+                else if (opcode == OP_SHA256)
+                    CSHA256().Write(begin_ptr(vch), vch.size()).Finalize(begin_ptr(vchHash));
+                else if (opcode == OP_HASH160)
+                    CHash160().Write(begin_ptr(vch), vch.size()).Finalize(begin_ptr(vchHash));
+                else if (opcode == OP_HASH256)
+                    CHash256().Write(begin_ptr(vch), vch.size()).Finalize(begin_ptr(vchHash));
+                popstack(stack);
+                stack.push_back(vchHash);
+            }
+            break;
+
+            case OP_CHECKSIG:
+            case OP_CHECKSIGVERIFY:
+            {
+                // (sig pubkey -- bool)
+                if (stack.size() < 2)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+
+                valtype& vchSig    = stacktop(-2);
+                valtype& vchPubKey = stacktop(-1);
+
+                if (!CheckSignatureEncoding(vchSig, flags, serror) || !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
+                    //serror is set
+                    return false;
                 }
-                break;
+                bool fSuccess = checker.CheckSig(vchSig, vchPubKey, script, consensusBranchId);
 
-                case OP_CHECKSIG:
-                case OP_CHECKSIGVERIFY:
+                popstack(stack);
+                popstack(stack);
+                stack.push_back(fSuccess ? vchTrue : vchFalse);
+                if (opcode == OP_CHECKSIGVERIFY)
                 {
-                    // (sig pubkey -- bool)
-                    if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                    if (fSuccess)
+                        popstack(stack);
+                    else
+                        return set_error(serror, SCRIPT_ERR_CHECKSIGVERIFY);
+                }
+            }
+            break;
 
-                    valtype& vchSig    = stacktop(-2);
-                    valtype& vchPubKey = stacktop(-1);
+            case OP_CHECKMULTISIG:
+            case OP_CHECKMULTISIGVERIFY:
+            {
+                // ([sig ...] num_of_signatures [pubkey ...] num_of_pubkeys -- bool)
 
+                int i = 1;
+                if ((int)stack.size() < i)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+
+                int nKeysCount = CScriptNum(stacktop(-i), fRequireMinimal).getint();
+                if (nKeysCount < 0 || nKeysCount > 20)
+                    return set_error(serror, SCRIPT_ERR_PUBKEY_COUNT);
+                nOpCount += nKeysCount;
+                if (nOpCount > 201)
+                    return set_error(serror, SCRIPT_ERR_OP_COUNT);
+                int ikey = ++i;
+                i += nKeysCount;
+                if ((int)stack.size() < i)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+
+                int nSigsCount = CScriptNum(stacktop(-i), fRequireMinimal).getint();
+                if (nSigsCount < 0 || nSigsCount > nKeysCount)
+                    return set_error(serror, SCRIPT_ERR_SIG_COUNT);
+                int isig = ++i;
+                i += nSigsCount;
+                if ((int)stack.size() < i)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+
+                bool fSuccess = true;
+                while (fSuccess && nSigsCount > 0)
+                {
+                    valtype& vchSig    = stacktop(-isig);
+                    valtype& vchPubKey = stacktop(-ikey);
+
+                    // Note how this makes the exact order of pubkey/signature evaluation
+                    // distinguishable by CHECKMULTISIG NOT if the STRICTENC flag is set.
+                    // See the script_(in)valid tests for details.
                     if (!CheckSignatureEncoding(vchSig, flags, serror) || !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
-                        //serror is set
+                        // serror is set
                         return false;
                     }
-                    bool fSuccess = checker.CheckSig(vchSig, vchPubKey, script, consensusBranchId);
 
-                    popstack(stack);
-                    popstack(stack);
-                    stack.push_back(fSuccess ? vchTrue : vchFalse);
-                    if (opcode == OP_CHECKSIGVERIFY)
-                    {
-                        if (fSuccess)
-                            popstack(stack);
-                        else
-                            return set_error(serror, SCRIPT_ERR_CHECKSIGVERIFY);
+                    // Check signature
+                    bool fOk = checker.CheckSig(vchSig, vchPubKey, script, consensusBranchId);
+
+                    if (fOk) {
+                        isig++;
+                        nSigsCount--;
                     }
-                }
-                break;
+                    ikey++;
+                    nKeysCount--;
 
-                case OP_CHECKMULTISIG:
-                case OP_CHECKMULTISIGVERIFY:
+                    // If there are more signatures left than keys left,
+                    // then too many signatures have failed. Exit early,
+                    // without checking any further signatures.
+                    if (nSigsCount > nKeysCount)
+                        fSuccess = false;
+                }
+
+                // Clean up stack of actual arguments
+                while (i-- > 1)
+                    popstack(stack);
+
+                // A bug causes CHECKMULTISIG to consume one extra argument
+                // whose contents were not checked in any way.
+                //
+                // Unfortunately this is a potential source of mutability,
+                // so optionally verify it is exactly equal to zero prior
+                // to removing it from the stack.
+                if (stack.size() < 1)
+                    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                if ((flags & SCRIPT_VERIFY_NULLDUMMY) && stacktop(-1).size())
+                    return set_error(serror, SCRIPT_ERR_SIG_NULLDUMMY);
+                popstack(stack);
+
+                stack.push_back(fSuccess ? vchTrue : vchFalse);
+
+                if (opcode == OP_CHECKMULTISIGVERIFY)
                 {
-                    // ([sig ...] num_of_signatures [pubkey ...] num_of_pubkeys -- bool)
-
-                    int i = 1;
-                    if ((int)stack.size() < i)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-
-                    int nKeysCount = CScriptNum(stacktop(-i), fRequireMinimal).getint();
-                    if (nKeysCount < 0 || nKeysCount > 20)
-                        return set_error(serror, SCRIPT_ERR_PUBKEY_COUNT);
-                    nOpCount += nKeysCount;
-                    if (nOpCount > 201)
-                        return set_error(serror, SCRIPT_ERR_OP_COUNT);
-                    int ikey = ++i;
-                    i += nKeysCount;
-                    if ((int)stack.size() < i)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-
-                    int nSigsCount = CScriptNum(stacktop(-i), fRequireMinimal).getint();
-                    if (nSigsCount < 0 || nSigsCount > nKeysCount)
-                        return set_error(serror, SCRIPT_ERR_SIG_COUNT);
-                    int isig = ++i;
-                    i += nSigsCount;
-                    if ((int)stack.size() < i)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-
-                    bool fSuccess = true;
-                    while (fSuccess && nSigsCount > 0)
-                    {
-                        valtype& vchSig    = stacktop(-isig);
-                        valtype& vchPubKey = stacktop(-ikey);
-
-                        // Note how this makes the exact order of pubkey/signature evaluation
-                        // distinguishable by CHECKMULTISIG NOT if the STRICTENC flag is set.
-                        // See the script_(in)valid tests for details.
-                        if (!CheckSignatureEncoding(vchSig, flags, serror) || !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
-                            // serror is set
-                            return false;
-                        }
-
-                        // Check signature
-                        bool fOk = checker.CheckSig(vchSig, vchPubKey, script, consensusBranchId);
-
-                        if (fOk) {
-                            isig++;
-                            nSigsCount--;
-                        }
-                        ikey++;
-                        nKeysCount--;
-
-                        // If there are more signatures left than keys left,
-                        // then too many signatures have failed. Exit early,
-                        // without checking any further signatures.
-                        if (nSigsCount > nKeysCount)
-                            fSuccess = false;
-                    }
-
-                    // Clean up stack of actual arguments
-                    while (i-- > 1)
+                    if (fSuccess)
                         popstack(stack);
-
-                    // A bug causes CHECKMULTISIG to consume one extra argument
-                    // whose contents were not checked in any way.
-                    //
-                    // Unfortunately this is a potential source of mutability,
-                    // so optionally verify it is exactly equal to zero prior
-                    // to removing it from the stack.
-                    if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    if ((flags & SCRIPT_VERIFY_NULLDUMMY) && stacktop(-1).size())
-                        return set_error(serror, SCRIPT_ERR_SIG_NULLDUMMY);
-                    popstack(stack);
-
-                    stack.push_back(fSuccess ? vchTrue : vchFalse);
-
-                    if (opcode == OP_CHECKMULTISIGVERIFY)
-                    {
-                        if (fSuccess)
-                            popstack(stack);
-                        else
-                            return set_error(serror, SCRIPT_ERR_CHECKMULTISIGVERIFY);
-                    }
+                    else
+                        return set_error(serror, SCRIPT_ERR_CHECKMULTISIGVERIFY);
                 }
-                break;
-
-                default:
-                    return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
             }
+            break;
 
-            // Size limits
-            if (stack.size() + altstack.size() > 1000)
-                return set_error(serror, SCRIPT_ERR_STACK_SIZE);
+            default:
+                return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
         }
-    }
-    catch (...)
-    {
-        return set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
-    }
 
-    if (!vfExec.empty())
-        return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+    // Size limits
+    if (stack.size() + altstack.size() > 1000)
+        return set_error(serror, SCRIPT_ERR_STACK_SIZE);
 
-    return set_success(serror);
+    return true;
 }
 
 bool CallbackTransactionSignatureChecker::VerifySignature(

--- a/depend/zcash/src/script/interpreter.h
+++ b/depend/zcash/src/script/interpreter.h
@@ -137,6 +137,22 @@ public:
     bool CheckLockTime(const CScriptNum& nLockTime) const;
 };
 
+struct State {
+    std::vector<std::vector<unsigned char>> stack;
+    std::vector<std::vector<unsigned char>> altstack{};
+    std::vector<bool> vfExec{};
+    int nOpCount{0};
+};
+
+/// Runs one step of the evaluator, allowing incremental inspection.
+bool EvalStep(
+    struct State& state,
+    const CScript& script,
+    CScript::const_iterator& pc,
+    unsigned int flags,
+    const BaseSignatureChecker& checker,
+    uint32_t consensusBranchId,
+    ScriptError* serror);
 
 bool EvalScript(
     std::vector<std::vector<unsigned char> >& stack,

--- a/depend/zcash/src/script/script.h
+++ b/depend/zcash/src/script/script.h
@@ -194,7 +194,6 @@ class CScriptNum
  * throwing an exception if arithmetic is done or the result is interpreted as an integer.
  */
 public:
-
     explicit CScriptNum(const int64_t& n)
     {
         m_value = n;

--- a/depend/zcash/src/script/zcash_script.h
+++ b/depend/zcash/src/script/zcash_script.h
@@ -7,6 +7,8 @@
 #ifndef ZCASH_SCRIPT_ZCASH_SCRIPT_H
 #define ZCASH_SCRIPT_ZCASH_SCRIPT_H
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "script_error.h"
 
@@ -93,6 +95,30 @@ EXPORT_SYMBOL int zcash_script_verify_callback(
     unsigned int scriptSigLen,
     unsigned int flags,
     ScriptError* err);
+
+EXPORT_SYMBOL struct ZcashScriptState {
+    unsigned char const** stack;
+    size_t* stackElemLen;
+    size_t stackLen;
+    unsigned char const** altstack;
+    size_t* altstackElemLen;
+    size_t altstackLen;
+    char* vfExec;
+    size_t vfExecLen;
+    int nOpCount;
+};
+
+EXPORT_SYMBOL int zcash_script_eval_step(
+    unsigned int flags,
+    const void* ctx,
+    void (*sighash)(unsigned char* sighash, unsigned int sighashLen, const void* ctx, const unsigned char* scriptCode, unsigned int scriptCodeLen, int hashType),
+    int64_t nLockTime,
+    uint8_t isFinal,
+    struct ZcashScriptState* state,
+    unsigned char const* script,
+    size_t scriptLen,
+    size_t* pc,
+    ScriptError* serror);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/cxx.rs
+++ b/src/cxx.rs
@@ -82,7 +82,7 @@ mod tests {
             )
         };
 
-        assert!(ret == 1);
+        assert_eq!(ret, 1);
     }
 
     #[test]
@@ -109,6 +109,7 @@ mod tests {
             )
         };
 
-        assert!(ret != 1);
+        assert_eq!(ret, 0);
+        assert_eq!(err, super::ScriptError_t_SCRIPT_ERR_EVAL_FALSE);
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -41,6 +41,7 @@ pub struct HashType {
 }
 
 /// Things that can go wrong when constructing a `HashType` from bit flags.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum InvalidHashType {
     /// Either or both of the two least-significant bits must be set.
     UnknownSignedOutputs,
@@ -187,6 +188,10 @@ impl<T: Clone> Stack<T> {
         Stack(vec![])
     }
 
+    pub fn from_parts(v: Vec<T>) -> Self {
+        Stack(v)
+    }
+
     fn reverse_index(&self, i: isize) -> Result<usize, ScriptError> {
         usize::try_from(-i)
             .map(|a| self.0.len() - a)
@@ -252,6 +257,10 @@ impl<T: Clone> Stack<T> {
 
     pub fn end(&self) -> usize {
         self.0.len()
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.0.as_mut_ptr()
     }
 }
 
@@ -1238,7 +1247,7 @@ pub trait StepFn {
     fn call<'a>(
         &self,
         pc: &'a [u8],
-        script: &Script,
+        script: &'a Script,
         state: &mut State,
         payload: &mut Self::Payload,
     ) -> Result<&'a [u8], ScriptError>;
@@ -1256,7 +1265,7 @@ impl<C: SignatureChecker + Copy> StepFn for DefaultStepEvaluator<C> {
     fn call<'a>(
         &self,
         pc: &'a [u8],
-        script: &Script,
+        script: &'a Script,
         state: &mut State,
         _payload: &mut (),
     ) -> Result<&'a [u8], ScriptError> {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -683,6 +683,9 @@ pub fn eval_step<'a>(
                         let mut value = false;
                         if exec {
                             if stack.size() < 1 {
+                                // TODO: This preserves what I think is a bug in the C++ impl – I
+                                //       think this should return
+                                //       [ScriptError::InvalidStackOperation], like every other similar case.
                                 return set_error(ScriptError::UnbalancedConditional);
                             }
                             let vch: &ValType = stack.top(-1)?;

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -117,7 +117,7 @@ impl<'a, T: Clone, U: Clone> StepFn for ComparisonStepEvaluator<'a, T, U> {
     fn call<'b>(
         &self,
         pc: &'b [u8],
-        script: &Script,
+        script: &'b Script,
         state: &mut State,
         payload: &mut StepResults<T, U>,
     ) -> Result<&'b [u8], ScriptError> {
@@ -146,7 +146,9 @@ impl<'a, T: Clone, U: Clone> StepFn for ComparisonStepEvaluator<'a, T, U> {
             }
             // at least one is `Err`
             (_, _) => {
-                if left != right {
+                if left.map_err(crate::normalize_script_error)
+                    != right.map_err(crate::normalize_script_error)
+                {
                     payload.diverging_result = Some((
                         left.map(|_| state.clone()),
                         right.map(|_| right_state.clone()),


### PR DESCRIPTION
This PR exposes stepwise evaluation on the C++ and runs it against the Rust side to ensure the state is identical every step of the way.

There are two commits here. The first one makes minimal changes to the C++ interpreter to expose an `EvalStep` function. It should be reviewed with whitespace ignored, since the body of the interpreter is reindented without changes.

The second commit implements the comparison work, changing the `zcash_script.h` interface.