### PR TITLE
Remove extra `&` from `SighashCalculator`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ pub struct ComparisonInterpreter<T, U> {
 }
 
 pub fn cxx_rust_comparison_interpreter<'a>(
-    sighash: &'a SighashCalculator<'a>,
+    sighash: SighashCalculator<'a>,
     lock_time: u32,
     is_final: bool,
     flags: VerificationFlags,


### PR DESCRIPTION
It‘s odd that the previous code worked (in some cases).