### PR TITLE
bump to 0.3.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directory: '/'
+    # Update only the lockfile. We shouldn't update Cargo.toml unless it's for
+    # a security issue, or if we need a new feature of the dependency.
+    versioning-strategy: lockfile-only
     schedule:
       interval: daily
       timezone: America/New_York

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           command: check
 
-  # Test that "cargo package" works. This make sure it's publishable,
+  # Test that "cargo package" works. This makes sure it's publishable,
   # since we had issues where "cargo build" worked but "package" didn't.
   package:
     name: Package
@@ -76,7 +76,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # "windows-latest" was removed; see https://github.com/ZcashFoundation/zcash_script/issues/38
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [0.3.1](https://github.com/ZcashFoundation/zcash_script/compare/v0.3.0...v0.3.1) - 2025-05-17
+
+### Other
+
+- Remove extra `&` from `SighashCalculator` ([#216](https://github.com/ZcashFoundation/zcash_script/pull/216))
+
 ## [0.3.0](https://github.com/ZcashFoundation/zcash_script/compare/v0.2.0...v0.3.0) - 2025-05-13
 
 - Another major API update. The previous C++ functions were moved to the `cxx`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zcash_script"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_script"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Electric Coin Company <info@electriccoin.co>",
     "Greg Pfeil <greg@technomadic.org>",
@@ -73,25 +73,21 @@ ripemd = "0.1"
 secp256k1 = "0.30"
 sha-1 = "0.10"
 sha2 = "0.10"
-tracing = "0.1.41"
+tracing = "0.1"
 
 [build-dependencies]
-# The `bindgen` dependency should automatically upgrade to match the version used by zebra-state's `rocksdb` dependency in:
-# https://github.com/ZcashFoundation/zebra/blob/main/zebra-state/Cargo.toml
-#
-# Treat minor versions with a zero major version as compatible (cargo doesn't by default).
-bindgen = ">= 0.64.0"
-
-# These dependencies are shared with a lot of other Zebra dependencies,
-# so they are configured to automatically upgrade to match Zebra.
-# But we try to use the latest versions here, to catch any bugs in `zcash_script`'s CI.
-cc = { version = "1.2.11", features = ["parallel"] }
+# We want zcash-script to be compatible with whatever version of `bindgen` that
+# is being indirectly used by Zebra via the `rocksdb` dependency. To avoid
+# having to update zcash-script every time Zebra updates its `rocksdb`
+# dependency, we allow any version of `bindgen`, even major version bumps, by
+# using the `>=` operator. There is some chance that this breaks the build if a
+# breaking API change affects us, but we can always fix it then.
+bindgen = ">= 0.69.5"
+# Same reasoning as above
+cc = { version = ">= 1.2.11", features = ["parallel"] }
 
 [dev-dependencies]
-# These dependencies are shared with a lot of other Zebra dependencies.
-# (See above.)
-#
-# Treat minor versions with a zero major version as compatible (cargo doesn't by default).
+# Same reasoning as above
 hex = ">= 0.4.3"
 lazy_static = "1.5.0"
 proptest = "1.6"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,3 +2,4 @@
 # TODO: C++ linking on Linux broke in 1.82, but is fixed again in 1.85. This can be bumped once that
 #       is released.
 channel = "1.81"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
also sneaked in the dependabot change to only updated lockfile, and some related Cargo.toml adjustments