### PR TITLE
Update the Rust toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+rust-version = "1.85" # C++ linking was broken in rust 1.82–1.84
 name = "zcash_script"
 version = "0.3.2"
 authors = [

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::GenerateBindings => write!(f, "unable to generate bindings: try running 'git submodule init' and 'git submodule update'"),
-            Error::WriteBindings(source) => write!(f, "unable to write bindings: {}", source),
+            Error::WriteBindings(source) => write!(f, "unable to write bindings: {source}"),
             Error::Env(source) => source.fmt(f),
         }
     }

--- a/build.rs
+++ b/build.rs
@@ -35,9 +35,12 @@ fn bindgen_headers() -> Result<()> {
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        // This should not reference a version newer than rust-toolchain.toml. See
-        // rust-lang/rust-bindgen#3049 for a potential future solution.
-        .rust_target(bindgen::RustTarget::Stable_1_73)
+        // Remove this once rust-lang/rust-bindgen#3049 is fixed.
+        .rust_target(
+            env!("CARGO_PKG_RUST_VERSION")
+                .parse()
+                .expect("package.rust-version is set in Cargo.toml"),
+        )
         // Finish the builder and generate the bindings.
         .generate()
         .map_err(|_| Error::GenerateBindings)?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,3 @@
 [toolchain]
-# TODO: C++ linking on Linux broke in 1.82, but is fixed again in 1.85. This can be bumped once that
-#       is released.
-channel = "1.81"
+channel = "stable"
 components = ["clippy", "rustfmt"]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1361,7 +1361,7 @@ where
                 eval_script(remaining_stack, &Script(pub_key_2), payload, stepper)
             })
             .and_then(|p2sh_stack| {
-                if p2sh_stack.last().map_or(false, cast_to_bool) {
+                if p2sh_stack.last().is_ok_and(cast_to_bool) {
                     Ok(p2sh_stack)
                 } else {
                     Err(ScriptError::EvalFalse)
@@ -1387,7 +1387,7 @@ where
     } else {
         let data_stack = eval_script(Stack::new(), script_sig, payload, stepper)?;
         let pub_key_stack = eval_script(data_stack.clone(), script_pub_key, payload, stepper)?;
-        if pub_key_stack.last().map_or(false, cast_to_bool) {
+        if pub_key_stack.last().is_ok_and(cast_to_bool) {
             if flags.contains(VerificationFlags::P2SH) && script_pub_key.is_pay_to_script_hash() {
                 eval_p2sh(data_stack, script_sig, payload, stepper)
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ extern "C" fn sighash_callback(
 }
 
 /// This steals a bit of the wrapper code from zebra_script, to provide the API that they want.
-impl<'a> ZcashScript for CxxInterpreter<'a> {
+impl ZcashScript for CxxInterpreter<'_> {
     fn verify_callback(
         &self,
         script_pub_key: &[u8],

--- a/src/script.rs
+++ b/src/script.rs
@@ -358,7 +358,7 @@ pub fn serialize_num(value: i64) -> Vec<u8> {
     // - If the most significant byte is < 0x80 and the value is negative, add 0x80 to it, since it
     //   will be subtracted and interpreted as a negative when converting to an integral.
 
-    if result.last().map_or(true, |last| last & 0x80 != 0) {
+    if result.last().is_none_or(|last| last & 0x80 != 0) {
         result.push(if neg { 0x80 } else { 0 });
     } else if neg {
         if let Some(last) = result.last_mut() {

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -121,7 +121,7 @@ pub struct ComparisonStepEvaluator<'a, T, U> {
     pub eval_step_r: &'a dyn StepFn<Payload = U>,
 }
 
-impl<'a, T: Clone, U: Clone> StepFn for ComparisonStepEvaluator<'a, T, U> {
+impl<T: Clone, U: Clone> StepFn for ComparisonStepEvaluator<'_, T, U> {
     type Payload = StepResults<T, U>;
     fn call<'b>(
         &self,


### PR DESCRIPTION
It was pinned to 1.81 because of a C++ linking issue in later versions. But now that 1.85 (and later) has been released, we can move to “stable”, and bump the MSRV (because it was previously the MaximumRSV, since later releases didn’t work).

This also makes bindgen track the MSRV more consistently for the code it generates.