### PR TITLE
Partition Operation enum

### DIFF
--- a/src/external/pubkey.rs
+++ b/src/external/pubkey.rs
@@ -1,56 +1,37 @@
 use secp256k1::{ecdsa, Message, PublicKey, Secp256k1};
 
-/// FIXME: `PUBLIC_KEY_SIZE` is meant to be an upper bound, it seems. Maybe parameterize the type
-///        over the size.
 pub struct PubKey<'a>(pub &'a [u8]);
 
 impl PubKey<'_> {
-    pub const PUBLIC_KEY_SIZE: usize = 65;
-    pub const COMPRESSED_PUBLIC_KEY_SIZE: usize = 33;
+    pub const SIZE: usize = 65;
+    pub const COMPRESSED_SIZE: usize = 33;
 
     /// Check syntactic correctness.
     ///
-    /// Note that this is consensus critical as CheckSig() calls it!
+    /// Note that this is consensus critical as `check_sig` calls it!
     pub fn is_valid(&self) -> bool {
         !self.0.is_empty()
     }
 
     /// Verify a DER signature (~72 bytes).
     /// If this public key is not fully valid, the return value will be false.
-    pub fn verify(&self, hash: &[u8; 32], vch_sig: &[u8]) -> bool {
+    pub fn verify(&self, hash: &[u8; 32], sig: &ecdsa::Signature) -> bool {
         if !self.is_valid() {
             return false;
         };
 
         if let Ok(pubkey) = PublicKey::from_slice(self.0) {
-            // let sig: secp256k1_ecdsa_signature;
-            if vch_sig.is_empty() {
-                return false;
-            };
-            // Zcash, unlike Bitcoin, has always enforced strict DER signatures.
-            if let Ok(mut sig) = ecdsa::Signature::from_der(vch_sig) {
-                // libsecp256k1's ECDSA verification requires lower-S signatures, which have
-                // not historically been enforced in Bitcoin or Zcash, so normalize them first.
-                sig.normalize_s();
-                let secp = Secp256k1::verification_only();
-                secp.verify_ecdsa(&Message::from_digest(*hash), &sig, &pubkey)
-                    .is_ok()
-            } else {
-                false
-            }
+            let secp = Secp256k1::verification_only();
+            secp.verify_ecdsa(&Message::from_digest(*hash), sig, &pubkey)
+                .is_ok()
         } else {
             false
         }
     }
 
-    pub fn check_low_s(vch_sig: &[u8]) -> bool {
-        /* Zcash, unlike Bitcoin, has always enforced strict DER signatures. */
-        if let Ok(sig) = ecdsa::Signature::from_der(vch_sig) {
-            let mut check = sig;
-            check.normalize_s();
-            sig == check
-        } else {
-            false
-        }
+    pub fn check_low_s(sig: &ecdsa::Signature) -> bool {
+        let mut check = *sig;
+        check.normalize_s();
+        *sig == check
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1357,62 +1357,55 @@ where
     F: StepFn,
 {
     if flags.contains(VerificationFlags::SigPushOnly) && !script_sig.is_push_only() {
-        return Err(ScriptError::SigPushOnly);
-    }
-
-    let data_stack = eval_script(Stack::new(), script_sig, payload, stepper)?;
-    let pub_key_stack = eval_script(data_stack.clone(), script_pub_key, payload, stepper)?;
-    if pub_key_stack.is_empty() {
-        return Err(ScriptError::EvalFalse);
-    }
-    if !cast_to_bool(pub_key_stack.last()?) {
-        return Err(ScriptError::EvalFalse);
-    }
-
-    // Additional validation for spend-to-script-hash transactions:
-    let result_stack = if flags.contains(VerificationFlags::P2SH)
-        && script_pub_key.is_pay_to_script_hash()
-    {
-        // script_sig must be literals-only or validation fails
-        if !script_sig.is_push_only() {
-            return Err(ScriptError::SigPushOnly);
-        };
-
-        // stack cannot be empty here, because if it was the
-        // P2SH  HASH <> EQUAL  scriptPubKey would be evaluated with
-        // an empty stack and the `eval_script` above would return false.
-        assert!(!data_stack.is_empty());
-
-        data_stack
-            .split_last()
-            .map_err(|_| ScriptError::InvalidStackOperation)
-            .and_then(|(pub_key_serialized, remaining_stack)| {
-                let pub_key_2 = Script(pub_key_serialized);
-
-                eval_script(remaining_stack, &pub_key_2, payload, stepper).and_then(|p2sh_stack| {
-                    if p2sh_stack.is_empty() {
-                        return Err(ScriptError::EvalFalse);
-                    }
-                    if !cast_to_bool(p2sh_stack.last()?) {
-                        return Err(ScriptError::EvalFalse);
-                    }
-                    Ok(p2sh_stack)
-                })
-            })?
+        Err(ScriptError::SigPushOnly)
     } else {
-        pub_key_stack
-    };
+        let data_stack = eval_script(Stack::new(), script_sig, payload, stepper)?;
+        let pub_key_stack = eval_script(data_stack.clone(), script_pub_key, payload, stepper)?;
+        if pub_key_stack.last().map_or(false, cast_to_bool) {
+            // Additional validation for spend-to-script-hash transactions:
+            let result_stack = if flags.contains(VerificationFlags::P2SH)
+                && script_pub_key.is_pay_to_script_hash()
+            {
+                // script_sig must be literals-only or validation fails
+                if script_sig.is_push_only() {
+                    data_stack
+                        // stack cannot be empty here, because if it was the P2SH HASH <> EQUAL
+                        // scriptPubKey would be evaluated with an empty stack and the `eval_script`
+                        // above would return false.
+                        .split_last()
+                        .and_then(|(pub_key_2, remaining_stack)| {
+                            eval_script(remaining_stack, &Script(pub_key_2), payload, stepper)
+                        })
+                        .and_then(|p2sh_stack| {
+                            if p2sh_stack.last().map_or(false, cast_to_bool) {
+                                Ok(p2sh_stack)
+                            } else {
+                                Err(ScriptError::EvalFalse)
+                            }
+                        })
+                } else {
+                    Err(ScriptError::SigPushOnly)
+                }?
+            } else {
+                pub_key_stack
+            };
 
-    // The CLEANSTACK check is only performed after potential P2SH evaluation,
-    // as the non-P2SH evaluation of a P2SH script will obviously not result in
-    // a clean stack (the P2SH inputs remain).
-    if flags.contains(VerificationFlags::CleanStack) {
-        // Disallow CLEANSTACK without P2SH, because Bitcoin did.
-        assert!(flags.contains(VerificationFlags::P2SH));
-        if result_stack.len() != 1 {
-            return Err(ScriptError::CleanStack);
+            // The CLEANSTACK check is only performed after potential P2SH evaluation,
+            // as the non-P2SH evaluation of a P2SH script will obviously not result in
+            // a clean stack (the P2SH inputs remain).
+            if flags.contains(VerificationFlags::CleanStack) {
+                // Disallow CLEANSTACK without P2SH, because Bitcoin did.
+                assert!(flags.contains(VerificationFlags::P2SH));
+                if result_stack.len() == 1 {
+                    Ok(())
+                } else {
+                    Err(ScriptError::CleanStack)
+                }
+            } else {
+                Ok(())
+            }
+        } else {
+            Err(ScriptError::EvalFalse)
         }
-    };
-
-    Ok(())
+    }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -9,7 +9,7 @@ use sha1::Sha1;
 use sha2::{Digest, Sha256};
 
 use super::external::pubkey::PubKey;
-use super::script::{Operation::*, PushValue::*, *};
+use super::script::{Control::*, Normal::*, PushValue::*, *};
 use super::script_error::*;
 
 /// The ways in which a transparent input may commit to the transparent outputs of its
@@ -455,11 +455,173 @@ pub fn eval_step<'a>(
     checker: impl SignatureChecker,
     state: &mut State,
 ) -> Result<&'a [u8], ScriptError> {
+    //
+    // Read instruction
+    //
+    Script::get_op2(pc).and_then(|(opcode, vch_push_value, new_pc)| {
+        eval_opcode(flags, opcode, vch_push_value, script, &checker, state).map(|()| new_pc)
+    })
+}
+
+fn eval_opcode(
+    flags: VerificationFlags,
+    opcode: Opcode,
+    vch_push_value: &[u8],
+    script: &Script,
+    checker: &dyn SignatureChecker,
+    state: &mut State,
+) -> Result<(), ScriptError> {
     let stack = &mut state.stack;
     let op_count = &mut state.op_count;
-    let require_minimal = flags.contains(VerificationFlags::MinimalData);
     let vexec = &mut state.vexec;
     let altstack = &mut state.altstack;
+
+    (match opcode {
+        Opcode::PushValue(pv) => {
+            if vch_push_value.len() <= MAX_SCRIPT_ELEMENT_SIZE {
+                if should_exec(vexec) {
+                    eval_push_value(
+                        pv,
+                        vch_push_value,
+                        flags.contains(VerificationFlags::MinimalData),
+                        stack,
+                    )
+                } else {
+                    Ok(())
+                }
+            } else {
+                Err(ScriptError::PushSize)
+            }
+        }
+        Opcode::Operation(op) => {
+            // Note how OP_RESERVED does not count towards the opcode limit.
+            *op_count += 1;
+            if *op_count <= 201 {
+                match op {
+                    Operation::Control(control) => eval_control(control, stack, vexec),
+                    Operation::Normal(normal) => {
+                        if should_exec(vexec) {
+                            eval_operation(
+                                normal, flags, script, checker, stack, altstack, op_count,
+                            )
+                        } else {
+                            Ok(())
+                        }
+                    }
+                    Operation::Unknown(_) => {
+                        if should_exec(vexec) {
+                            Err(ScriptError::BadOpcode)
+                        } else {
+                            Ok(())
+                        }
+                    }
+                }
+            } else {
+                Err(ScriptError::OpCount)
+            }
+        }
+    })
+    .and_then(|()| {
+        // Size limits
+        if stack.len() + altstack.len() > 1000 {
+            Err(ScriptError::StackSize)
+        } else {
+            Ok(())
+        }
+    })
+}
+
+fn eval_push_value(
+    pv: PushValue,
+    vch_push_value: &[u8],
+    require_minimal: bool,
+    stack: &mut Stack<Vec<u8>>,
+) -> Result<(), ScriptError> {
+    match pv {
+        //
+        // Push value
+        //
+        OP_1NEGATE | OP_1 | OP_2 | OP_3 | OP_4 | OP_5 | OP_6 | OP_7 | OP_8 | OP_9 | OP_10
+        | OP_11 | OP_12 | OP_13 | OP_14 | OP_15 | OP_16 => {
+            // ( -- value)
+            let bn = i64::from(u8::from(pv)) - i64::from(u8::from(OP_RESERVED));
+            stack.push(serialize_num(bn));
+            // The result of these opcodes should always be the minimal way to push the data
+            // they push, so no need for a CheckMinimalPush here.
+        }
+        _ => {
+            if pv <= OP_PUSHDATA4 {
+                if require_minimal && !check_minimal_push(vch_push_value, pv) {
+                    return Err(ScriptError::MinimalData);
+                }
+                stack.push(vch_push_value.to_vec());
+            } else {
+                return Err(ScriptError::BadOpcode);
+            }
+        }
+    }
+    Ok(())
+}
+
+// Are we in an executing branch of the script?
+fn should_exec(vexec: &Stack<bool>) -> bool {
+    vexec.iter().all(|value| *value)
+}
+
+/// <expression> if [statements] [else [statements]] endif
+fn eval_control(
+    op: Control,
+    stack: &mut Stack<Vec<u8>>,
+    vexec: &mut Stack<bool>,
+) -> Result<(), ScriptError> {
+    match op {
+        OP_IF | OP_NOTIF => {
+            // <expression> if [statements] [else [statements]] endif
+            let mut value = false;
+            if should_exec(vexec) {
+                if stack.is_empty() {
+                    return Err(ScriptError::UnbalancedConditional);
+                }
+                let vch: &ValType = stack.rget(0)?;
+                value = cast_to_bool(vch);
+                if op == OP_NOTIF {
+                    value = !value
+                };
+                stack.pop()?;
+            }
+            vexec.push(value);
+        }
+
+        OP_ELSE => {
+            if vexec.is_empty() {
+                return Err(ScriptError::UnbalancedConditional);
+            }
+            vexec.last_mut().map(|last| *last = !*last)?;
+        }
+
+        OP_ENDIF => {
+            if vexec.is_empty() {
+                return Err(ScriptError::UnbalancedConditional);
+            }
+            vexec.pop()?;
+        }
+
+        OP_VERIF | OP_VERNOTIF => return Err(ScriptError::BadOpcode),
+        _ => return Err(ScriptError::DisabledOpcode),
+    }
+    Ok(())
+}
+
+fn eval_operation(
+    op: Normal,
+    flags: VerificationFlags,
+    script: &Script,
+    checker: &dyn SignatureChecker,
+    stack: &mut Stack<Vec<u8>>,
+    altstack: &mut Stack<Vec<u8>>,
+    op_count: &mut u8,
+) -> Result<(), ScriptError> {
+    let require_minimal = flags.contains(VerificationFlags::MinimalData);
 
     let unfn_num =
         |stackin: &mut Stack<Vec<u8>>, op: &dyn Fn(i64) -> Vec<u8>| -> Result<(), ScriptError> {
@@ -494,606 +656,495 @@ pub fn eval_step<'a>(
         unfn_num(stack, &|bn| cast_from_bool(op(bn)))
     };
 
-    // Are we in an executing branch of the script?
-    let exec = vexec.iter().all(|value| *value);
+    match op {
+        //
+        // Control
+        //
+        OP_NOP => (),
 
-    //
-    // Read instruction
-    //
-    let (opcode, vch_push_value, new_pc) = Script::get_op2(pc)?;
-    if vch_push_value.len() > MAX_SCRIPT_ELEMENT_SIZE {
-        return Err(ScriptError::PushSize);
-    }
+        OP_CHECKLOCKTIMEVERIFY => {
+            // https://zips.z.cash/protocol/protocol.pdf#bips :
+            //
+            //   The following BIPs apply starting from the Zcash genesis block,
+            //   i.e. any activation rules or exceptions for particular blocks in
+            //   the Bitcoin block chain are to be ignored: [BIP-16], [BIP-30],
+            //   [BIP-65], [BIP-66].
+            //
+            // So BIP 65, which defines CHECKLOCKTIMEVERIFY, is in practice always
+            // enabled, and this `if` branch is dead code. In zcashd see
+            // https://github.com/zcash/zcash/blob/a3435336b0c561799ac6805a27993eca3f9656df/src/main.cpp#L3151
+            if !flags.contains(VerificationFlags::CHECKLOCKTIMEVERIFY) {
+                if flags.contains(VerificationFlags::DiscourageUpgradableNOPs) {
+                    return Err(ScriptError::DiscourageUpgradableNOPs);
+                }
+            } else {
+                if stack.is_empty() {
+                    return Err(ScriptError::InvalidStackOperation);
+                }
 
-    match opcode {
-        Opcode::PushValue(pv) => {
-            if exec {
-                match pv {
-                    //
-                    // Push value
-                    //
-                    OP_1NEGATE | OP_1 | OP_2 | OP_3 | OP_4 | OP_5 | OP_6 | OP_7 | OP_8 | OP_9
-                    | OP_10 | OP_11 | OP_12 | OP_13 | OP_14 | OP_15 | OP_16 => {
-                        // ( -- value)
-                        let bn = i64::from(u8::from(pv)) - i64::from(u8::from(OP_RESERVED));
-                        stack.push(serialize_num(bn));
-                        // The result of these opcodes should always be the minimal way to push the data
-                        // they push, so no need for a CheckMinimalPush here.
-                    }
-                    _ => {
-                        if pv <= OP_PUSHDATA4 {
-                            if require_minimal && !check_minimal_push(vch_push_value, pv) {
-                                return Err(ScriptError::MinimalData);
-                            }
-                            stack.push(vch_push_value.to_vec());
-                        } else {
-                            return Err(ScriptError::BadOpcode);
-                        }
-                    }
+                // Note that elsewhere numeric opcodes are limited to
+                // operands in the range -2**31+1 to 2**31-1, however it is
+                // legal for opcodes to produce results exceeding that
+                // range. This limitation is implemented by `ScriptNum`'s
+                // default 4-byte limit.
+                //
+                // If we kept to that limit we'd have a year 2038 problem,
+                // even though the `lock_time` field in transactions
+                // themselves is u32 which only becomes meaningless
+                // after the year 2106.
+                //
+                // Thus as a special case we tell `ScriptNum` to accept up
+                // to 5-byte bignums, which are good until 2**39-1, well
+                // beyond the 2**32-1 limit of the `lock_time` field itself.
+                let lock_time = parse_num(stack.rget(0)?, require_minimal, Some(5))?;
+
+                // In the rare event that the argument may be < 0 due to
+                // some arithmetic being done first, you can always use
+                // 0 MAX CHECKLOCKTIMEVERIFY.
+                if lock_time < 0 {
+                    return Err(ScriptError::NegativeLockTime);
+                }
+
+                // Actually compare the specified lock time with the transaction.
+                if !checker.check_lock_time(lock_time) {
+                    return Err(ScriptError::UnsatisfiedLockTime);
                 }
             }
         }
-        Opcode::Operation(op) => {
-            // Note how OP_RESERVED does not count towards the opcode limit.
-            *op_count += 1;
+
+        OP_NOP1 | OP_NOP3 | OP_NOP4 | OP_NOP5 | OP_NOP6 | OP_NOP7 | OP_NOP8 | OP_NOP9
+        | OP_NOP10 => {
+            // Do nothing, though if the caller wants to prevent people from using
+            // these NOPs (as part of a standard tx rule, for example) they can
+            // enable `DiscourageUpgradableNOPs` to turn these opcodes into errors.
+            if flags.contains(VerificationFlags::DiscourageUpgradableNOPs) {
+                return Err(ScriptError::DiscourageUpgradableNOPs);
+            }
+        }
+
+        OP_VERIFY => {
+            // (true -- ) or
+            // (false -- false) and return
+            if stack.is_empty() {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let value = cast_to_bool(stack.rget(0)?);
+            if value {
+                stack.pop()?;
+            } else {
+                return Err(ScriptError::Verify);
+            }
+        }
+
+        OP_RETURN => return Err(ScriptError::OpReturn),
+
+        //
+        // Stack ops
+        //
+        OP_TOALTSTACK => {
+            if stack.is_empty() {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            altstack.push(stack.rget(0)?.clone());
+            stack.pop()?;
+        }
+
+        OP_FROMALTSTACK => {
+            if altstack.is_empty() {
+                return Err(ScriptError::InvalidAltstackOperation);
+            }
+            stack.push(altstack.rget(0)?.clone());
+            altstack.pop()?;
+        }
+
+        OP_2DROP => {
+            if stack.len() < 2 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+
+            stack.pop()?;
+            stack.pop()?;
+        }
+
+        OP_2DUP => {
+            // (x1 x2 -- x1 x2 x1 x2)
+            if stack.len() < 2 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let vch1 = stack.rget(1)?.clone();
+            let vch2 = stack.rget(0)?.clone();
+            stack.push(vch1);
+            stack.push(vch2);
+        }
+
+        OP_3DUP => {
+            // (x1 x2 x3 -- x1 x2 x3 x1 x2 x3)
+            if stack.len() < 3 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let vch1 = stack.rget(2)?.clone();
+            let vch2 = stack.rget(1)?.clone();
+            let vch3 = stack.rget(0)?.clone();
+            stack.push(vch1);
+            stack.push(vch2);
+            stack.push(vch3);
+        }
+
+        OP_2OVER => {
+            // (x1 x2 x3 x4 -- x1 x2 x3 x4 x1 x2)
+            if stack.len() < 4 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let vch1 = stack.rget(3)?.clone();
+            let vch2 = stack.rget(2)?.clone();
+            stack.push(vch1);
+            stack.push(vch2);
+        }
+
+        OP_2ROT => {
+            // (x1 x2 x3 x4 x5 x6 -- x3 x4 x5 x6 x1 x2)
+            if stack.len() < 6 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let vch1 = stack.rget(5)?.clone();
+            let vch2 = stack.rget(4)?.clone();
+            stack.rerase(5, Some(3))?;
+            stack.push(vch1);
+            stack.push(vch2);
+        }
+
+        OP_2SWAP => {
+            // (x1 x2 x3 x4 -- x3 x4 x1 x2)
+            if stack.len() < 4 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            stack.rswap(3, 1)?;
+            stack.rswap(2, 0)?;
+        }
+
+        OP_IFDUP => {
+            // (x - 0 | x x)
+            if stack.is_empty() {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let vch = stack.rget(0)?;
+            if cast_to_bool(vch) {
+                stack.push(vch.to_vec())
+            }
+        }
+
+        OP_DEPTH => {
+            // -- stacksize
+            let bn = i64::try_from(stack.len()).map_err(|_| ScriptError::StackSize)?;
+            stack.push(serialize_num(bn))
+        }
+
+        OP_DROP => {
+            // (x -- )
+            if stack.is_empty() {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            stack.pop()?;
+        }
+
+        OP_DUP => {
+            // (x -- x x)
+            if stack.is_empty() {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+
+            let vch = stack.rget(0)?;
+            stack.push(vch.clone());
+        }
+
+        OP_NIP => {
+            // (x1 x2 -- x2)
+            if stack.len() < 2 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            stack.rerase(1, None)?;
+        }
+
+        OP_OVER => {
+            // (x1 x2 -- x1 x2 x1)
+            if stack.len() < 2 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let vch = stack.rget(1)?;
+            stack.push(vch.clone());
+        }
+
+        OP_PICK | OP_ROLL => {
+            // (xn ... x2 x1 x0 n - xn ... x2 x1 x0 xn)
+            // (xn ... x2 x1 x0 n - ... x2 x1 x0 xn)
+            if stack.len() < 2 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let n = u16::try_from(parse_num(stack.rget(0)?, require_minimal, None)?)
+                .map_err(|_| ScriptError::InvalidStackOperation)?;
+            stack.pop()?;
+            if usize::from(n) >= stack.len() {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let vch: ValType = stack.rget(n.into())?.clone();
+            if op == OP_ROLL {
+                stack.rerase(n.into(), None)?;
+            }
+            stack.push(vch)
+        }
+
+        OP_ROT => {
+            // (x1 x2 x3 -- x2 x3 x1)
+            //  x2 x1 x3  after first swap
+            //  x2 x3 x1  after second swap
+            if stack.len() < 3 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            stack.rswap(2, 1)?;
+            stack.rswap(1, 0)?;
+        }
+
+        OP_SWAP => {
+            // (x1 x2 -- x2 x1)
+            if stack.len() < 2 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            stack.rswap(1, 0)?;
+        }
+
+        OP_TUCK => {
+            // (x1 x2 -- x2 x1 x2)
+            if stack.len() < 2 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let vch = stack.rget(0)?.clone();
+            stack.rinsert(1, vch)?
+        }
+
+        OP_SIZE => {
+            // (in -- in size)
+            if stack.is_empty() {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let bn = i64::try_from(stack.rget(0)?.len())
+                .expect("stack element size <= MAX_SCRIPT_ELEMENT_SIZE");
+            stack.push(serialize_num(bn))
+        }
+
+        //
+        // Bitwise logic
+        //
+        // (x1 x2 - bool)
+        OP_EQUAL => binop(stack, |x1, x2| Ok(cast_from_bool(x1 == x2)))?,
+        OP_EQUALVERIFY => binfn(stack, |x1, x2| {
+            if x1 == x2 {
+                Ok(())
+            } else {
+                Err(ScriptError::EqualVerify)
+            }
+        })?,
+
+        //
+        // Numeric
+        //
+
+        // (in -- out)
+        OP_1ADD => unop_num(stack, &|x| x + 1)?,
+        OP_1SUB => unop_num(stack, &|x| x - 1)?,
+        OP_NEGATE => unop_num(stack, &|x| -x)?,
+        OP_ABS => unop_num(stack, &|x| x.abs())?,
+        OP_NOT => unrel(stack, &|x| x == 0)?,
+        OP_0NOTEQUAL => unrel(stack, &|x| x != 0)?,
+
+        // (x1 x2 -- out)
+        OP_ADD => binop_num(stack, &|x1, x2| x1 + x2)?,
+        OP_SUB => binop_num(stack, &|x1, x2| x1 - x2)?,
+        OP_BOOLAND => binrel(stack, &|x1, x2| x1 != 0 && x2 != 0)?,
+        OP_BOOLOR => binrel(stack, &|x1, x2| x1 != 0 || x2 != 0)?,
+        OP_NUMEQUAL => binrel(stack, &|x1, x2| x1 == x2)?,
+        OP_NUMEQUALVERIFY => binbasic_num(stack, require_minimal, |x1, x2| {
+            if x1 == x2 {
+                Ok(())
+            } else {
+                Err(ScriptError::NumEqualVerify)
+            }
+        })?,
+        OP_NUMNOTEQUAL => binrel(stack, &|x1, x2| x1 != x2)?,
+        OP_LESSTHAN => binrel(stack, &|x1, x2| x1 < x2)?,
+        OP_GREATERTHAN => binrel(stack, &|x1, x2| x1 > x2)?,
+        OP_LESSTHANOREQUAL => binrel(stack, &|x1, x2| x1 <= x2)?,
+        OP_GREATERTHANOREQUAL => binrel(stack, &|x1, x2| x1 >= x2)?,
+        OP_MIN => binop_num(stack, &min)?,
+        OP_MAX => binop_num(stack, &max)?,
+
+        OP_WITHIN => {
+            // (x min max -- out)
+            if stack.len() < 3 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let bn1 = parse_num(stack.rget(2)?, require_minimal, None)?;
+            let bn2 = parse_num(stack.rget(1)?, require_minimal, None)?;
+            let bn3 = parse_num(stack.rget(0)?, require_minimal, None)?;
+            let value = bn2 <= bn1 && bn1 < bn3;
+            stack.pop()?;
+            stack.pop()?;
+            stack.pop()?;
+            stack.push(cast_from_bool(value))
+        }
+
+        //
+        // Crypto
+        //
+        OP_RIPEMD160 | OP_SHA1 | OP_SHA256 | OP_HASH160 | OP_HASH256 => {
+            // (in -- hash)
+            if stack.is_empty() {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            let vch = stack.rget(0)?;
+            let mut vch_hash = vec![];
+            if op == OP_RIPEMD160 {
+                vch_hash = Ripemd160::digest(vch).to_vec();
+            } else if op == OP_SHA1 {
+                let mut hasher = Sha1::new();
+                hasher.update(vch);
+                vch_hash = hasher.finalize().to_vec();
+            } else if op == OP_SHA256 {
+                vch_hash = Sha256::digest(vch).to_vec();
+            } else if op == OP_HASH160 {
+                vch_hash = Ripemd160::digest(Sha256::digest(vch)).to_vec();
+            } else if op == OP_HASH256 {
+                vch_hash = Sha256::digest(Sha256::digest(vch)).to_vec();
+            }
+            stack.pop()?;
+            stack.push(vch_hash)
+        }
+
+        OP_CHECKSIG | OP_CHECKSIGVERIFY => {
+            // (sig pubkey -- bool)
+            if stack.len() < 2 {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+
+            let vch_sig = stack.rget(1)?.clone();
+            let vch_pub_key = stack.rget(0)?.clone();
+
+            let success = is_sig_valid(&vch_sig, &vch_pub_key, flags, script, checker)?;
+
+            stack.pop()?;
+            stack.pop()?;
+            stack.push(cast_from_bool(success));
+            if op == OP_CHECKSIGVERIFY {
+                if success {
+                    stack.pop()?;
+                } else {
+                    return Err(ScriptError::CheckSigVerify);
+                }
+            }
+        }
+
+        OP_CHECKMULTISIG | OP_CHECKMULTISIGVERIFY => {
+            // ([sig ...] num_of_signatures [pubkey ...] num_of_pubkeys -- bool)
+
+            // NB: This is guaranteed u8-safe, because we are limited to 20 keys and
+            //     20 signatures, plus a couple other fields. u8 also gives us total
+            //     conversions to the other types we deal with here (`isize` and `i64`).
+            let mut i: u8 = 0;
+            if stack.len() < i.into() {
+                return Err(ScriptError::InvalidStackOperation);
+            };
+
+            let mut keys_count =
+                u8::try_from(parse_num(stack.rget(i.into())?, require_minimal, None)?)
+                    .map_err(|_| ScriptError::PubKeyCount)?;
+            if keys_count > 20 {
+                return Err(ScriptError::PubKeyCount);
+            };
+            assert!(*op_count <= 201);
+            *op_count += keys_count;
             if *op_count > 201 {
                 return Err(ScriptError::OpCount);
+            };
+            i += 1;
+            let mut ikey = i;
+            i += keys_count;
+            if stack.len() <= i.into() {
+                return Err(ScriptError::InvalidStackOperation);
             }
 
-            if op == OP_CAT
-                || op == OP_SUBSTR
-                || op == OP_LEFT
-                || op == OP_RIGHT
-                || op == OP_INVERT
-                || op == OP_AND
-                || op == OP_OR
-                || op == OP_XOR
-                || op == OP_2MUL
-                || op == OP_2DIV
-                || op == OP_MUL
-                || op == OP_DIV
-                || op == OP_MOD
-                || op == OP_LSHIFT
-                || op == OP_RSHIFT
-                || op == OP_CODESEPARATOR
-            {
-                return Err(ScriptError::DisabledOpcode); // Disabled opcodes.
+            let mut sigs_count =
+                u8::try_from(parse_num(stack.rget(i.into())?, require_minimal, None)?)
+                    .map_err(|_| ScriptError::SigCount)?;
+            if sigs_count > keys_count {
+                return Err(ScriptError::SigCount);
+            };
+            assert!(i <= 21);
+            i += 1;
+            let mut isig = i;
+            i += sigs_count;
+            if stack.len() <= i.into() {
+                return Err(ScriptError::InvalidStackOperation);
+            };
+
+            let mut success = true;
+            while success && sigs_count > 0 {
+                let vch_sig: &ValType = stack.rget(isig.into())?;
+                let vch_pub_key: &ValType = stack.rget(ikey.into())?;
+
+                // Note how this makes the exact order of pubkey/signature evaluation
+                // distinguishable by CHECKMULTISIG NOT if the STRICTENC flag is set.
+                // See the script_(in)valid tests for details.
+                let ok: bool = is_sig_valid(vch_sig, vch_pub_key, flags, script, checker)?;
+
+                if ok {
+                    isig += 1;
+                    sigs_count -= 1;
+                }
+                ikey += 1;
+                keys_count -= 1;
+
+                // If there are more signatures left than keys left,
+                // then too many signatures have failed. Exit early,
+                // without checking any further signatures.
+                if sigs_count > keys_count {
+                    success = false;
+                };
             }
 
-            if exec || (OP_IF <= op && op <= OP_ENDIF) {
-                match op {
-                    //
-                    // Control
-                    //
-                    OP_NOP => (),
+            // Clean up stack of actual arguments
+            for _ in 0..i {
+                stack.pop()?;
+            }
 
-                    OP_CHECKLOCKTIMEVERIFY => {
-                        // https://zips.z.cash/protocol/protocol.pdf#bips :
-                        //
-                        //   The following BIPs apply starting from the Zcash genesis block,
-                        //   i.e. any activation rules or exceptions for particular blocks in
-                        //   the Bitcoin block chain are to be ignored: [BIP-16], [BIP-30],
-                        //   [BIP-65], [BIP-66].
-                        //
-                        // So BIP 65, which defines CHECKLOCKTIMEVERIFY, is in practice always
-                        // enabled, and this `if` branch is dead code. In zcashd see
-                        // https://github.com/zcash/zcash/blob/a3435336b0c561799ac6805a27993eca3f9656df/src/main.cpp#L3151
-                        if !flags.contains(VerificationFlags::CHECKLOCKTIMEVERIFY) {
-                            if flags.contains(VerificationFlags::DiscourageUpgradableNOPs) {
-                                return Err(ScriptError::DiscourageUpgradableNOPs);
-                            }
-                        } else {
-                            if stack.is_empty() {
-                                return Err(ScriptError::InvalidStackOperation);
-                            }
+            // A bug causes CHECKMULTISIG to consume one extra argument
+            // whose contents were not checked in any way.
+            //
+            // Unfortunately this is a potential source of mutability,
+            // so optionally verify it is exactly equal to zero prior
+            // to removing it from the stack.
+            if stack.is_empty() {
+                return Err(ScriptError::InvalidStackOperation);
+            }
+            if flags.contains(VerificationFlags::NullDummy) && !stack.rget(0)?.is_empty() {
+                return Err(ScriptError::SigNullDummy);
+            }
+            stack.pop()?;
 
-                            // Note that elsewhere numeric opcodes are limited to
-                            // operands in the range -2**31+1 to 2**31-1, however it is
-                            // legal for opcodes to produce results exceeding that
-                            // range. This limitation is implemented by `ScriptNum`'s
-                            // default 4-byte limit.
-                            //
-                            // If we kept to that limit we'd have a year 2038 problem,
-                            // even though the `lock_time` field in transactions
-                            // themselves is u32 which only becomes meaningless
-                            // after the year 2106.
-                            //
-                            // Thus as a special case we tell `ScriptNum` to accept up
-                            // to 5-byte bignums, which are good until 2**39-1, well
-                            // beyond the 2**32-1 limit of the `lock_time` field itself.
-                            let lock_time = parse_num(stack.rget(0)?, require_minimal, Some(5))?;
+            stack.push(cast_from_bool(success));
 
-                            // In the rare event that the argument may be < 0 due to
-                            // some arithmetic being done first, you can always use
-                            // 0 MAX CHECKLOCKTIMEVERIFY.
-                            if lock_time < 0 {
-                                return Err(ScriptError::NegativeLockTime);
-                            }
-
-                            // Actually compare the specified lock time with the transaction.
-                            if !checker.check_lock_time(lock_time) {
-                                return Err(ScriptError::UnsatisfiedLockTime);
-                            }
-                        }
-                    }
-
-                    OP_NOP1 | OP_NOP3 | OP_NOP4 | OP_NOP5 | OP_NOP6 | OP_NOP7 | OP_NOP8
-                    | OP_NOP9 | OP_NOP10 => {
-                        // Do nothing, though if the caller wants to prevent people from using
-                        // these NOPs (as part of a standard tx rule, for example) they can
-                        // enable `DiscourageUpgradableNOPs` to turn these opcodes into errors.
-                        if flags.contains(VerificationFlags::DiscourageUpgradableNOPs) {
-                            return Err(ScriptError::DiscourageUpgradableNOPs);
-                        }
-                    }
-
-                    OP_IF | OP_NOTIF => {
-                        // <expression> if [statements] [else [statements]] endif
-                        let mut value = false;
-                        if exec {
-                            if stack.is_empty() {
-                                return Err(ScriptError::UnbalancedConditional);
-                            }
-                            let vch: &ValType = stack.rget(0)?;
-                            value = cast_to_bool(vch);
-                            if op == OP_NOTIF {
-                                value = !value
-                            };
-                            stack.pop()?;
-                        }
-                        vexec.push(value);
-                    }
-
-                    OP_ELSE => {
-                        if vexec.is_empty() {
-                            return Err(ScriptError::UnbalancedConditional);
-                        }
-                        vexec.last_mut().map(|last| *last = !*last)?;
-                    }
-
-                    OP_ENDIF => {
-                        if vexec.is_empty() {
-                            return Err(ScriptError::UnbalancedConditional);
-                        }
-                        vexec.pop()?;
-                    }
-
-                    OP_VERIFY => {
-                        // (true -- ) or
-                        // (false -- false) and return
-                        if stack.is_empty() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let value = cast_to_bool(stack.rget(0)?);
-                        if value {
-                            stack.pop()?;
-                        } else {
-                            return Err(ScriptError::Verify);
-                        }
-                    }
-
-                    OP_RETURN => return Err(ScriptError::OpReturn),
-
-                    //
-                    // Stack ops
-                    //
-                    OP_TOALTSTACK => {
-                        if stack.is_empty() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        altstack.push(stack.rget(0)?.clone());
-                        stack.pop()?;
-                    }
-
-                    OP_FROMALTSTACK => {
-                        if altstack.is_empty() {
-                            return Err(ScriptError::InvalidAltstackOperation);
-                        }
-                        stack.push(altstack.rget(0)?.clone());
-                        altstack.pop()?;
-                    }
-
-                    OP_2DROP => {
-                        if stack.len() < 2 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-
-                        stack.pop()?;
-                        stack.pop()?;
-                    }
-
-                    OP_2DUP => {
-                        // (x1 x2 -- x1 x2 x1 x2)
-                        if stack.len() < 2 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let vch1 = stack.rget(1)?.clone();
-                        let vch2 = stack.rget(0)?.clone();
-                        stack.push(vch1);
-                        stack.push(vch2);
-                    }
-
-                    OP_3DUP => {
-                        // (x1 x2 x3 -- x1 x2 x3 x1 x2 x3)
-                        if stack.len() < 3 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let vch1 = stack.rget(2)?.clone();
-                        let vch2 = stack.rget(1)?.clone();
-                        let vch3 = stack.rget(0)?.clone();
-                        stack.push(vch1);
-                        stack.push(vch2);
-                        stack.push(vch3);
-                    }
-
-                    OP_2OVER => {
-                        // (x1 x2 x3 x4 -- x1 x2 x3 x4 x1 x2)
-                        if stack.len() < 4 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let vch1 = stack.rget(3)?.clone();
-                        let vch2 = stack.rget(2)?.clone();
-                        stack.push(vch1);
-                        stack.push(vch2);
-                    }
-
-                    OP_2ROT => {
-                        // (x1 x2 x3 x4 x5 x6 -- x3 x4 x5 x6 x1 x2)
-                        if stack.len() < 6 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let vch1 = stack.rget(5)?.clone();
-                        let vch2 = stack.rget(4)?.clone();
-                        stack.rerase(5, Some(3))?;
-                        stack.push(vch1);
-                        stack.push(vch2);
-                    }
-
-                    OP_2SWAP => {
-                        // (x1 x2 x3 x4 -- x3 x4 x1 x2)
-                        if stack.len() < 4 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        stack.rswap(3, 1)?;
-                        stack.rswap(2, 0)?;
-                    }
-
-                    OP_IFDUP => {
-                        // (x - 0 | x x)
-                        if stack.is_empty() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let vch = stack.rget(0)?;
-                        if cast_to_bool(vch) {
-                            stack.push(vch.to_vec())
-                        }
-                    }
-
-                    OP_DEPTH => {
-                        // -- stacksize
-                        let bn = i64::try_from(stack.len()).map_err(|_| ScriptError::StackSize)?;
-                        stack.push(serialize_num(bn))
-                    }
-
-                    OP_DROP => {
-                        // (x -- )
-                        if stack.is_empty() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        stack.pop()?;
-                    }
-
-                    OP_DUP => {
-                        // (x -- x x)
-                        if stack.is_empty() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-
-                        let vch = stack.rget(0)?;
-                        stack.push(vch.clone());
-                    }
-
-                    OP_NIP => {
-                        // (x1 x2 -- x2)
-                        if stack.len() < 2 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        stack.rerase(1, None)?;
-                    }
-
-                    OP_OVER => {
-                        // (x1 x2 -- x1 x2 x1)
-                        if stack.len() < 2 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let vch = stack.rget(1)?;
-                        stack.push(vch.clone());
-                    }
-
-                    OP_PICK | OP_ROLL => {
-                        // (xn ... x2 x1 x0 n - xn ... x2 x1 x0 xn)
-                        // (xn ... x2 x1 x0 n - ... x2 x1 x0 xn)
-                        if stack.len() < 2 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let n = u16::try_from(parse_num(stack.rget(0)?, require_minimal, None)?)
-                            .map_err(|_| ScriptError::InvalidStackOperation)?;
-                        stack.pop()?;
-                        if usize::from(n) >= stack.len() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let vch: ValType = stack.rget(n.into())?.clone();
-                        if op == OP_ROLL {
-                            stack.rerase(n.into(), None)?;
-                        }
-                        stack.push(vch)
-                    }
-
-                    OP_ROT => {
-                        // (x1 x2 x3 -- x2 x3 x1)
-                        //  x2 x1 x3  after first swap
-                        //  x2 x3 x1  after second swap
-                        if stack.len() < 3 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        stack.rswap(2, 1)?;
-                        stack.rswap(1, 0)?;
-                    }
-
-                    OP_SWAP => {
-                        // (x1 x2 -- x2 x1)
-                        if stack.len() < 2 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        stack.rswap(1, 0)?;
-                    }
-
-                    OP_TUCK => {
-                        // (x1 x2 -- x2 x1 x2)
-                        if stack.len() < 2 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let vch = stack.rget(0)?.clone();
-                        stack.rinsert(1, vch)?
-                    }
-
-                    OP_SIZE => {
-                        // (in -- in size)
-                        if stack.is_empty() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let bn = i64::try_from(stack.rget(0)?.len())
-                            .expect("stack element size <= MAX_SCRIPT_ELEMENT_SIZE");
-                        stack.push(serialize_num(bn))
-                    }
-
-                    //
-                    // Bitwise logic
-                    //
-                    // (x1 x2 - bool)
-                    OP_EQUAL => binop(stack, |x1, x2| Ok(cast_from_bool(x1 == x2)))?,
-                    OP_EQUALVERIFY => binfn(stack, |x1, x2| {
-                        if x1 == x2 {
-                            Ok(())
-                        } else {
-                            Err(ScriptError::EqualVerify)
-                        }
-                    })?,
-
-                    //
-                    // Numeric
-                    //
-
-                    // (in -- out)
-                    OP_1ADD => unop_num(stack, &|x| x + 1)?,
-                    OP_1SUB => unop_num(stack, &|x| x - 1)?,
-                    OP_NEGATE => unop_num(stack, &|x| -x)?,
-                    OP_ABS => unop_num(stack, &|x| x.abs())?,
-                    OP_NOT => unrel(stack, &|x| x == 0)?,
-                    OP_0NOTEQUAL => unrel(stack, &|x| x != 0)?,
-
-                    // (x1 x2 -- out)
-                    OP_ADD => binop_num(stack, &|x1, x2| x1 + x2)?,
-                    OP_SUB => binop_num(stack, &|x1, x2| x1 - x2)?,
-                    OP_BOOLAND => binrel(stack, &|x1, x2| x1 != 0 && x2 != 0)?,
-                    OP_BOOLOR => binrel(stack, &|x1, x2| x1 != 0 || x2 != 0)?,
-                    OP_NUMEQUAL => binrel(stack, &|x1, x2| x1 == x2)?,
-                    OP_NUMEQUALVERIFY => binbasic_num(stack, require_minimal, |x1, x2| {
-                        if x1 == x2 {
-                            Ok(())
-                        } else {
-                            Err(ScriptError::NumEqualVerify)
-                        }
-                    })?,
-                    OP_NUMNOTEQUAL => binrel(stack, &|x1, x2| x1 != x2)?,
-                    OP_LESSTHAN => binrel(stack, &|x1, x2| x1 < x2)?,
-                    OP_GREATERTHAN => binrel(stack, &|x1, x2| x1 > x2)?,
-                    OP_LESSTHANOREQUAL => binrel(stack, &|x1, x2| x1 <= x2)?,
-                    OP_GREATERTHANOREQUAL => binrel(stack, &|x1, x2| x1 >= x2)?,
-                    OP_MIN => binop_num(stack, &min)?,
-                    OP_MAX => binop_num(stack, &max)?,
-
-                    OP_WITHIN => {
-                        // (x min max -- out)
-                        if stack.len() < 3 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let bn1 = parse_num(stack.rget(2)?, require_minimal, None)?;
-                        let bn2 = parse_num(stack.rget(1)?, require_minimal, None)?;
-                        let bn3 = parse_num(stack.rget(0)?, require_minimal, None)?;
-                        let value = bn2 <= bn1 && bn1 < bn3;
-                        stack.pop()?;
-                        stack.pop()?;
-                        stack.pop()?;
-                        stack.push(cast_from_bool(value))
-                    }
-
-                    //
-                    // Crypto
-                    //
-                    OP_RIPEMD160 | OP_SHA1 | OP_SHA256 | OP_HASH160 | OP_HASH256 => {
-                        // (in -- hash)
-                        if stack.is_empty() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        let vch = stack.rget(0)?;
-                        let mut vch_hash = vec![];
-                        if op == OP_RIPEMD160 {
-                            vch_hash = Ripemd160::digest(vch).to_vec();
-                        } else if op == OP_SHA1 {
-                            let mut hasher = Sha1::new();
-                            hasher.update(vch);
-                            vch_hash = hasher.finalize().to_vec();
-                        } else if op == OP_SHA256 {
-                            vch_hash = Sha256::digest(vch).to_vec();
-                        } else if op == OP_HASH160 {
-                            vch_hash = Ripemd160::digest(Sha256::digest(vch)).to_vec();
-                        } else if op == OP_HASH256 {
-                            vch_hash = Sha256::digest(Sha256::digest(vch)).to_vec();
-                        }
-                        stack.pop()?;
-                        stack.push(vch_hash)
-                    }
-
-                    OP_CHECKSIG | OP_CHECKSIGVERIFY => {
-                        // (sig pubkey -- bool)
-                        if stack.len() < 2 {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-
-                        let vch_sig = stack.rget(1)?.clone();
-                        let vch_pub_key = stack.rget(0)?.clone();
-
-                        let success =
-                            is_sig_valid(&vch_sig, &vch_pub_key, flags, script, &checker)?;
-
-                        stack.pop()?;
-                        stack.pop()?;
-                        stack.push(cast_from_bool(success));
-                        if op == OP_CHECKSIGVERIFY {
-                            if success {
-                                stack.pop()?;
-                            } else {
-                                return Err(ScriptError::CheckSigVerify);
-                            }
-                        }
-                    }
-
-                    OP_CHECKMULTISIG | OP_CHECKMULTISIGVERIFY => {
-                        // ([sig ...] num_of_signatures [pubkey ...] num_of_pubkeys -- bool)
-
-                        // NB: This is guaranteed u8-safe, because we are limited to 20 keys and
-                        //     20 signatures, plus a couple other fields. u8 also gives us total
-                        //     conversions to the other types we deal with here (`isize` and `i64`).
-                        let mut i: u8 = 0;
-                        if stack.len() < i.into() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        };
-
-                        let mut keys_count =
-                            u8::try_from(parse_num(stack.rget(i.into())?, require_minimal, None)?)
-                                .map_err(|_| ScriptError::PubKeyCount)?;
-                        if keys_count > 20 {
-                            return Err(ScriptError::PubKeyCount);
-                        };
-                        assert!(*op_count <= 201);
-                        *op_count += keys_count;
-                        if *op_count > 201 {
-                            return Err(ScriptError::OpCount);
-                        };
-                        i += 1;
-                        let mut ikey = i;
-                        i += keys_count;
-                        if stack.len() <= i.into() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-
-                        let mut sigs_count =
-                            u8::try_from(parse_num(stack.rget(i.into())?, require_minimal, None)?)
-                                .map_err(|_| ScriptError::SigCount)?;
-                        if sigs_count > keys_count {
-                            return Err(ScriptError::SigCount);
-                        };
-                        assert!(i <= 21);
-                        i += 1;
-                        let mut isig = i;
-                        i += sigs_count;
-                        if stack.len() <= i.into() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        };
-
-                        let mut success = true;
-                        while success && sigs_count > 0 {
-                            let vch_sig: &ValType = stack.rget(isig.into())?;
-                            let vch_pub_key: &ValType = stack.rget(ikey.into())?;
-
-                            // Note how this makes the exact order of pubkey/signature evaluation
-                            // distinguishable by CHECKMULTISIG NOT if the STRICTENC flag is set.
-                            // See the script_(in)valid tests for details.
-                            let ok: bool =
-                                is_sig_valid(vch_sig, vch_pub_key, flags, script, &checker)?;
-
-                            if ok {
-                                isig += 1;
-                                sigs_count -= 1;
-                            }
-                            ikey += 1;
-                            keys_count -= 1;
-
-                            // If there are more signatures left than keys left,
-                            // then too many signatures have failed. Exit early,
-                            // without checking any further signatures.
-                            if sigs_count > keys_count {
-                                success = false;
-                            };
-                        }
-
-                        // Clean up stack of actual arguments
-                        for _ in 0..i {
-                            stack.pop()?;
-                        }
-
-                        // A bug causes CHECKMULTISIG to consume one extra argument
-                        // whose contents were not checked in any way.
-                        //
-                        // Unfortunately this is a potential source of mutability,
-                        // so optionally verify it is exactly equal to zero prior
-                        // to removing it from the stack.
-                        if stack.is_empty() {
-                            return Err(ScriptError::InvalidStackOperation);
-                        }
-                        if flags.contains(VerificationFlags::NullDummy)
-                            && !stack.rget(0)?.is_empty()
-                        {
-                            return Err(ScriptError::SigNullDummy);
-                        }
-                        stack.pop()?;
-
-                        stack.push(cast_from_bool(success));
-
-                        if op == OP_CHECKMULTISIGVERIFY {
-                            if success {
-                                stack.pop()?;
-                            } else {
-                                return Err(ScriptError::CheckMultisigVerify);
-                            }
-                        }
-                    }
-
-                    _ => {
-                        return Err(ScriptError::BadOpcode);
-                    }
+            if op == OP_CHECKMULTISIGVERIFY {
+                if success {
+                    stack.pop()?;
+                } else {
+                    return Err(ScriptError::CheckMultisigVerify);
                 }
             }
         }
-    }
 
-    // Size limits
-    if stack.len() + altstack.len() > 1000 {
-        return Err(ScriptError::StackSize);
+        _ => {
+            return Err(ScriptError::BadOpcode);
+        }
     }
-
-    Ok(new_pc)
+    Ok(())
 }
 
 pub trait StepFn {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -9,7 +9,7 @@ use sha1::Sha1;
 use sha2::{Digest, Sha256};
 
 use super::external::pubkey::PubKey;
-use super::script::{Control::*, Normal::*, PushValue::*, *};
+use super::script::{Control::*, Normal::*, *};
 use super::script_error::*;
 
 /// The ways in which a transparent input may commit to the transparent outputs of its
@@ -94,7 +94,7 @@ bitflags::bitflags! {
         const SigPushOnly = 1 << 5;
 
         /// Require minimal encodings for all push operations (OP_0... OP_16, OP_1NEGATE where possible, direct
-        /// pushes up to 75 bytes, OP_PUSHDATA up to 255 bytes, OP_PUSHDATA2 for anything larger). Evaluating
+        /// pushes up to 75 bytes, OP_PUSHDATA1 up to 255 bytes, OP_PUSHDATA2 for anything larger). Evaluating
         /// any other push causes the script to fail ([BIP62](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki) rule 3).
         /// In addition, whenever a stack element is interpreted as a number, it must be of minimal length ([BIP62](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki) rule 4).
         /// (softfork safe)
@@ -306,29 +306,6 @@ fn check_pub_key_encoding(vch_sig: &[u8], flags: VerificationFlags) -> Result<()
     Ok(())
 }
 
-fn check_minimal_push(data: &[u8], opcode: PushValue) -> bool {
-    if data.is_empty() {
-        // Could have used OP_0.
-        return opcode == OP_0;
-    } else if data.len() == 1 && data[0] >= 1 && data[0] <= 16 {
-        // Could have used OP_1 .. OP_16.
-        return u8::from(opcode) == u8::from(OP_1) + (data[0] - 1);
-    } else if data.len() == 1 && data[0] == 0x81 {
-        // Could have used OP_1NEGATE.
-        return opcode == OP_1NEGATE;
-    } else if data.len() <= 75 {
-        // Could have used a direct push (opcode indicating number of bytes pushed + those bytes).
-        return usize::from(u8::from(opcode)) == data.len();
-    } else if data.len() <= 255 {
-        // Could have used OP_PUSHDATA.
-        return opcode == OP_PUSHDATA1;
-    } else if data.len() <= 65535 {
-        // Could have used OP_PUSHDATA2.
-        return opcode == OP_PUSHDATA2;
-    }
-    true
-}
-
 fn is_sig_valid(
     vch_sig: &[u8],
     vch_pub_key: &[u8],
@@ -458,15 +435,14 @@ pub fn eval_step<'a>(
     //
     // Read instruction
     //
-    Script::get_op2(pc).and_then(|(opcode, vch_push_value, new_pc)| {
-        eval_opcode(flags, opcode, vch_push_value, script, &checker, state).map(|()| new_pc)
+    Script::get_op(pc).and_then(|(opcode, new_pc)| {
+        eval_opcode(flags, opcode, script, &checker, state).map(|()| new_pc)
     })
 }
 
 fn eval_opcode(
     flags: VerificationFlags,
     opcode: Opcode,
-    vch_push_value: &[u8],
     script: &Script,
     checker: &dyn SignatureChecker,
     state: &mut State,
@@ -478,14 +454,9 @@ fn eval_opcode(
 
     (match opcode {
         Opcode::PushValue(pv) => {
-            if vch_push_value.len() <= MAX_SCRIPT_ELEMENT_SIZE {
+            if pv.value().map_or(0, |v| v.len()) <= MAX_SCRIPT_ELEMENT_SIZE {
                 if should_exec(vexec) {
-                    eval_push_value(
-                        pv,
-                        vch_push_value,
-                        flags.contains(VerificationFlags::MinimalData),
-                        stack,
-                    )
+                    eval_push_value(&pv, flags.contains(VerificationFlags::MinimalData), stack)
                 } else {
                     Ok(())
                 }
@@ -532,35 +503,18 @@ fn eval_opcode(
 }
 
 fn eval_push_value(
-    pv: PushValue,
-    vch_push_value: &[u8],
+    pv: &PushValue,
     require_minimal: bool,
     stack: &mut Stack<Vec<u8>>,
 ) -> Result<(), ScriptError> {
-    match pv {
-        //
-        // Push value
-        //
-        OP_1NEGATE | OP_1 | OP_2 | OP_3 | OP_4 | OP_5 | OP_6 | OP_7 | OP_8 | OP_9 | OP_10
-        | OP_11 | OP_12 | OP_13 | OP_14 | OP_15 | OP_16 => {
-            // ( -- value)
-            let bn = i64::from(u8::from(pv)) - i64::from(u8::from(OP_RESERVED));
-            stack.push(serialize_num(bn));
-            // The result of these opcodes should always be the minimal way to push the data
-            // they push, so no need for a CheckMinimalPush here.
-        }
-        _ => {
-            if pv <= OP_PUSHDATA4 {
-                if require_minimal && !check_minimal_push(vch_push_value, pv) {
-                    return Err(ScriptError::MinimalData);
-                }
-                stack.push(vch_push_value.to_vec());
-            } else {
-                return Err(ScriptError::BadOpcode);
-            }
-        }
+    if require_minimal && !pv.is_minimal_push() {
+        Err(ScriptError::MinimalData)
+    } else {
+        pv.value().map_or(Err(ScriptError::BadOpcode), |v| {
+            stack.push(v);
+            Ok(())
+        })
     }
-    Ok(())
 }
 
 // Are we in an executing branch of the script?

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use ripemd::Ripemd160;
+use secp256k1::ecdsa;
 use sha1::Sha1;
 use sha2::{Digest, Sha256};
 
@@ -41,15 +42,6 @@ pub struct HashType {
     pub signed_outputs: SignedOutputs,
     /// Allows anyone to add transparent inputs to this transaction.
     pub anyone_can_pay: bool,
-}
-
-/// Things that can go wrong when constructing a `HashType` from bit flags.
-pub enum InvalidHashType {
-    /// Either or both of the two least-significant bits must be set.
-    UnknownSignedOutputs,
-    /// With v5 transactions, bits other than those specified for `HashType` must be 0. The `i32`
-    /// includes only the bits that are undefined by `HashType`.
-    ExtraBitsSet(i32),
 }
 
 impl HashType {
@@ -133,7 +125,12 @@ bitflags::bitflags! {
 }
 
 pub trait SignatureChecker {
-    fn check_sig(&self, _script_sig: &[u8], _vch_pub_key: &[u8], _script_code: &Script) -> bool {
+    fn check_sig(
+        &self,
+        _script_sig: &Signature,
+        _vch_pub_key: &[u8],
+        _script_code: &Script,
+    ) -> bool {
         false
     }
 
@@ -255,179 +252,52 @@ impl<T: Clone> Stack<T> {
     }
 }
 
-fn is_compressed_or_uncompressed_pub_key(vch_pub_key: &ValType) -> bool {
-    if vch_pub_key.len() < PubKey::COMPRESSED_PUBLIC_KEY_SIZE {
-        //  Non-canonical public key: too short
-        return false;
+fn is_compressed_or_uncompressed_pub_key(vch_pub_key: &[u8]) -> bool {
+    match vch_pub_key.first() {
+        Some(0x02 | 0x03) => vch_pub_key.len() == PubKey::COMPRESSED_SIZE,
+        Some(0x04) => vch_pub_key.len() == PubKey::SIZE,
+        _ => false, // not a public key
     }
-    if vch_pub_key[0] == 0x04 {
-        if vch_pub_key.len() != PubKey::PUBLIC_KEY_SIZE {
-            //  Non-canonical public key: invalid length for uncompressed key
-            return false;
-        }
-    } else if vch_pub_key[0] == 0x02 || vch_pub_key[0] == 0x03 {
-        if vch_pub_key.len() != PubKey::COMPRESSED_PUBLIC_KEY_SIZE {
-            //  Non-canonical public key: invalid length for compressed key
-            return false;
-        }
-    } else {
-        //  Non-canonical public key: neither compressed nor uncompressed
-        return false;
+}
+
+#[derive(Clone)]
+pub struct Signature {
+    sig: ecdsa::Signature,
+    sighash: HashType,
+}
+
+fn decode_signature(vch_sig_in: &[u8], is_strict: bool) -> Result<Option<Signature>, ScriptError> {
+    match vch_sig_in.split_last() {
+        // Empty signature. Not strictly DER encoded, but allowed to provide a compact way to
+        // provide an invalid signature for use with CHECK(MULTI)SIG
+        None => Ok(None),
+        Some((hash_type, vch_sig)) => Ok(Some(Signature {
+            sig: ecdsa::Signature::from_der(vch_sig).map_err(|e| ScriptError::SigDER(Some(e)))?,
+            sighash: HashType::from_bits((*hash_type).into(), is_strict)
+                .map_err(|e| ScriptError::SigHashType(Some(e)))?,
+        })),
     }
-    true
-}
-
-/**
- * A canonical signature consists of: <30> <total len> <02> <len R> <R> <02> <len S> <S> <hashtype>
- * Where R and S are not negative (their first byte has its highest bit not set), and not
- * excessively padded (do not start with a 0 byte, unless an otherwise negative number follows,
- * in which case a single 0 byte is necessary and even required).
- *
- * See https://bitcointalk.org/index.php?topic=8392.msg127623#msg127623
- *
- * This function is consensus-critical since BIP66.
- */
-fn is_valid_signature_encoding(sig: &[u8]) -> bool {
-    // Format: 0x30 [total-length] 0x02 [R-length] [R] 0x02 [S-length] [S] [sighash]
-    // * total-length: 1-byte length descriptor of everything that follows,
-    //   excluding the sighash byte.
-    // * R-length: 1-byte length descriptor of the R value that follows.
-    // * R: arbitrary-length big-endian encoded R value. It must use the shortest
-    //   possible encoding for a positive integer (which means no null bytes at
-    //   the start, except a single one when the next byte has its highest bit set).
-    // * S-length: 1-byte length descriptor of the S value that follows.
-    // * S: arbitrary-length big-endian encoded S value. The same rules apply.
-    // * sighash: 1-byte value indicating what data is hashed (not part of the DER
-    //   signature)
-
-    // Minimum and maximum size constraints.
-    if sig.len() < 9 {
-        return false;
-    };
-    if sig.len() > 73 {
-        return false;
-    };
-
-    // A signature is of type 0x30 (compound).
-    if sig[0] != 0x30 {
-        return false;
-    };
-
-    // Make sure the length covers the entire signature.
-    if usize::from(sig[1]) != sig.len() - 3 {
-        return false;
-    };
-
-    // Extract the length of the R element.
-    let len_r = usize::from(sig[3]);
-
-    // Make sure the length of the S element is still inside the signature.
-    if 5 + len_r >= sig.len() {
-        return false;
-    };
-
-    // Extract the length of the S element.
-    let len_s = usize::from(sig[5 + len_r]);
-
-    // Verify that the length of the signature matches the sum of the length
-    // of the elements.
-    if len_r + len_s + 7 != sig.len() {
-        return false;
-    };
-
-    // Check whether the R element is an integer.
-    if sig[2] != 0x02 {
-        return false;
-    };
-
-    // Zero-length integers are not allowed for R.
-    if len_r == 0 {
-        return false;
-    };
-
-    // Negative numbers are not allowed for R.
-    if sig[4] & 0x80 != 0 {
-        return false;
-    };
-
-    // Null bytes at the start of R are not allowed, unless R would
-    // otherwise be interpreted as a negative number.
-    if len_r > 1 && sig[4] == 0x00 && sig[5] & 0x80 == 0 {
-        return false;
-    };
-
-    // Check whether the S element is an integer.
-    if sig[len_r + 4] != 0x02 {
-        return false;
-    };
-
-    // Zero-length integers are not allowed for S.
-    if len_s == 0 {
-        return false;
-    };
-
-    // Negative numbers are not allowed for S.
-    if sig[len_r + 6] & 0x80 != 0 {
-        return false;
-    };
-
-    // Null bytes at the start of S are not allowed, unless S would otherwise be
-    // interpreted as a negative number.
-    if len_s > 1 && sig[len_r + 6] == 0x00 && sig[len_r + 7] & 0x80 == 0 {
-        return false;
-    };
-
-    true
-}
-
-fn is_low_der_signature(vch_sig: &ValType) -> Result<bool, ScriptError> {
-    if !is_valid_signature_encoding(vch_sig) {
-        return Err(ScriptError::SigDER);
-    };
-    // https://bitcoin.stackexchange.com/a/12556:
-    //     Also note that inside transaction signatures, an extra hashtype byte
-    //     follows the actual signature data.
-    let (_, vch_sig_copy) = vch_sig
-        .split_last()
-        .expect("`is_valid_signature_encoding` checks that the length is at least 9");
-    // If the S value is above the order of the curve divided by two, its
-    // complement modulo the order could have been used instead, which is
-    // one byte shorter when encoded correctly.
-    // FIXME: This can return `false` without setting an error, which is not the expectation of the
-    //        caller.
-    Ok(PubKey::check_low_s(vch_sig_copy))
-}
-
-fn is_defined_hashtype_signature(vch_sig: &ValType) -> bool {
-    if vch_sig.is_empty() {
-        return false;
-    };
-
-    HashType::from_bits(i32::from(vch_sig[vch_sig.len() - 1]), true).is_ok()
 }
 
 fn check_signature_encoding(
-    vch_sig: &Vec<u8>,
+    vch_sig: &[u8],
     flags: VerificationFlags,
-) -> Result<(), ScriptError> {
-    // Empty signature. Not strictly DER encoded, but allowed to provide a
-    // compact way to provide an invalid signature for use with CHECK(MULTI)SIG
-    if vch_sig.is_empty() {
-        return Ok(());
-    };
-    if !is_valid_signature_encoding(vch_sig) {
-        return Err(ScriptError::SigDER);
-    } else if flags.contains(VerificationFlags::LowS) && !is_low_der_signature(vch_sig)? {
-        return Err(ScriptError::SigHighS);
-    } else if flags.contains(VerificationFlags::StrictEnc)
-        && !is_defined_hashtype_signature(vch_sig)
-    {
-        return Err(ScriptError::SigHashType);
-    };
-    Ok(())
+) -> Result<Option<Signature>, ScriptError> {
+    decode_signature(vch_sig, flags.contains(VerificationFlags::StrictEnc)).and_then(
+        |sig| match sig {
+            None => Ok(None),
+            Some(sig0) => {
+                if flags.contains(VerificationFlags::LowS) && !PubKey::check_low_s(&sig0.sig) {
+                    Err(ScriptError::SigHighS)
+                } else {
+                    Ok(Some(sig0))
+                }
+            }
+        },
+    )
 }
 
-fn check_pub_key_encoding(vch_sig: &ValType, flags: VerificationFlags) -> Result<(), ScriptError> {
+fn check_pub_key_encoding(vch_sig: &[u8], flags: VerificationFlags) -> Result<(), ScriptError> {
     if flags.contains(VerificationFlags::StrictEnc)
         && !is_compressed_or_uncompressed_pub_key(vch_sig)
     {
@@ -457,6 +327,20 @@ fn check_minimal_push(data: &[u8], opcode: PushValue) -> bool {
         return opcode == OP_PUSHDATA2;
     }
     true
+}
+
+fn is_sig_valid(
+    vch_sig: &[u8],
+    vch_pub_key: &[u8],
+    flags: VerificationFlags,
+    script: &Script<'_>,
+    checker: &dyn SignatureChecker,
+) -> Result<bool, ScriptError> {
+    let sig = check_signature_encoding(vch_sig, flags)?;
+    check_pub_key_encoding(vch_pub_key, flags).map(|()| {
+        sig.map(|sig0| checker.check_sig(&sig0, vch_pub_key, script))
+            .unwrap_or(false)
+    })
 }
 
 fn unop<T: Clone>(
@@ -1080,9 +964,8 @@ pub fn eval_step<'a>(
                         let vch_sig = stack.rget(1)?.clone();
                         let vch_pub_key = stack.rget(0)?.clone();
 
-                        check_signature_encoding(&vch_sig, flags)?;
-                        check_pub_key_encoding(&vch_pub_key, flags)?;
-                        let success = checker.check_sig(&vch_sig, &vch_pub_key, script);
+                        let success =
+                            is_sig_valid(&vch_sig, &vch_pub_key, flags, script, &checker)?;
 
                         stack.pop()?;
                         stack.pop()?;
@@ -1147,11 +1030,8 @@ pub fn eval_step<'a>(
                             // Note how this makes the exact order of pubkey/signature evaluation
                             // distinguishable by CHECKMULTISIG NOT if the STRICTENC flag is set.
                             // See the script_(in)valid tests for details.
-                            check_signature_encoding(vch_sig, flags)?;
-                            check_pub_key_encoding(vch_pub_key, flags)?;
-
-                            // Check signature
-                            let ok: bool = checker.check_sig(vch_sig, vch_pub_key, script);
+                            let ok: bool =
+                                is_sig_valid(vch_sig, vch_pub_key, flags, script, &checker)?;
 
                             if ok {
                                 isig += 1;
@@ -1291,28 +1171,14 @@ pub const SIGHASH_SIZE: usize = 32;
 /// reporting, but returning `None` indicates _some_ failure to produce the desired hash.
 pub type SighashCalculator<'a> = &'a dyn Fn(&[u8], HashType) -> Option<[u8; SIGHASH_SIZE]>;
 
-impl CallbackTransactionSignatureChecker<'_> {
-    pub fn verify_signature(vch_sig: &[u8], pubkey: &PubKey, sighash: &[u8; SIGHASH_SIZE]) -> bool {
-        pubkey.verify(sighash, vch_sig)
-    }
-}
-
 impl SignatureChecker for CallbackTransactionSignatureChecker<'_> {
-    fn check_sig(&self, vch_sig_in: &[u8], vch_pub_key: &[u8], script_code: &Script) -> bool {
+    fn check_sig(&self, sig: &Signature, vch_pub_key: &[u8], script_code: &Script) -> bool {
         let pubkey = PubKey(vch_pub_key);
-        if !pubkey.is_valid() {
-            return false;
-        };
 
-        // Hash type is one byte tacked on to the end of the signature
-        match vch_sig_in.split_last() {
-            None => false,
-            Some((hash_type, vch_sig)) => HashType::from_bits((*hash_type).into(), false)
-                .ok()
-                .and_then(|hash_type| (self.sighash)(script_code.0, hash_type))
-                .map(|sighash| Self::verify_signature(vch_sig, &pubkey, &sighash))
-                .unwrap_or(false),
-        }
+        pubkey.is_valid()
+            && (self.sighash)(script_code.0, sig.sighash)
+                .map(|sighash| pubkey.verify(&sighash, &sig.sig))
+                .unwrap_or(false)
     }
 
     fn check_lock_time(&self, lock_time: i64) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,8 @@ impl From<cxx::ScriptError> for Error {
                 Error::Ok(ScriptError::UnsatisfiedLockTime)
             }
 
-            cxx::ScriptError_t_SCRIPT_ERR_SIG_HASHTYPE => Error::Ok(ScriptError::SigHashType),
-            cxx::ScriptError_t_SCRIPT_ERR_SIG_DER => Error::Ok(ScriptError::SigDER),
+            cxx::ScriptError_t_SCRIPT_ERR_SIG_HASHTYPE => Error::Ok(ScriptError::SigHashType(None)),
+            cxx::ScriptError_t_SCRIPT_ERR_SIG_DER => Error::Ok(ScriptError::SigDER(None)),
             cxx::ScriptError_t_SCRIPT_ERR_MINIMALDATA => Error::Ok(ScriptError::MinimalData),
             cxx::ScriptError_t_SCRIPT_ERR_SIG_PUSHONLY => Error::Ok(ScriptError::SigPushOnly),
             cxx::ScriptError_t_SCRIPT_ERR_SIG_HIGH_S => Error::Ok(ScriptError::SigHighS),
@@ -212,6 +212,8 @@ pub fn check_verify_callback<T: ZcashScript, U: ZcashScript>(
 pub fn normalize_error(err: Error) -> Error {
     match err {
         Error::Ok(serr) => Error::Ok(match serr {
+            ScriptError::SigHashType(Some(_)) => ScriptError::SigHashType(None),
+            ScriptError::SigDER(Some(_)) => ScriptError::SigDER(None),
             ScriptError::ReadError { .. } => ScriptError::BadOpcode,
             ScriptError::ScriptNumError(_) => ScriptError::UnknownError,
             _ => serr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,7 @@ pub mod testing {
     use super::*;
     use crate::{
         interpreter::{State, StepFn},
-        script::{Operation, Script},
+        script::{Normal, Script},
     };
 
     /// Ensures that flags represent a supported state. This avoids crashes in the C++ code, which
@@ -328,7 +328,7 @@ pub mod testing {
             payload: &mut T::Payload,
         ) -> Result<&'a [u8], ScriptError> {
             self.0.call(
-                if pc[0] == Operation::OP_EQUAL.into() {
+                if pc[0] == Normal::OP_EQUAL.into() {
                     &pc[1..]
                 } else {
                     pc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ extern crate enum_primitive;
 pub mod cxx;
 mod external;
 pub mod interpreter;
+pub mod op;
+pub mod pv;
 mod script;
 pub mod script_error;
 mod zcash_script;

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,0 +1,157 @@
+//! Convenience definitions for all opcodes.
+
+use crate::{
+    pv,
+    script::{
+        Control::*,
+        Normal::*,
+        Opcode::{self, *},
+        Operation::*,
+    },
+};
+
+pub const _0: Opcode = PushValue(pv::_0);
+pub const _1NEGATE: Opcode = PushValue(pv::_1NEGATE);
+pub const _1: Opcode = PushValue(pv::_1);
+pub const _2: Opcode = PushValue(pv::_2);
+pub const _3: Opcode = PushValue(pv::_3);
+pub const _4: Opcode = PushValue(pv::_4);
+pub const _5: Opcode = PushValue(pv::_5);
+pub const _6: Opcode = PushValue(pv::_6);
+pub const _7: Opcode = PushValue(pv::_7);
+pub const _8: Opcode = PushValue(pv::_8);
+pub const _9: Opcode = PushValue(pv::_9);
+pub const _10: Opcode = PushValue(pv::_10);
+pub const _11: Opcode = PushValue(pv::_11);
+pub const _12: Opcode = PushValue(pv::_12);
+pub const _13: Opcode = PushValue(pv::_13);
+pub const _14: Opcode = PushValue(pv::_14);
+pub const _15: Opcode = PushValue(pv::_15);
+pub const _16: Opcode = PushValue(pv::_16);
+
+pub fn pushdata_bytelength(value: Vec<u8>) -> Opcode {
+    PushValue(pv::pushdata_bytelength(value))
+}
+
+pub fn pushdata1(value: Vec<u8>) -> Opcode {
+    PushValue(pv::pushdata1(value))
+}
+
+pub fn pushdata2(value: Vec<u8>) -> Opcode {
+    PushValue(pv::pushdata2(value))
+}
+
+pub fn pushdata4(value: Vec<u8>) -> Opcode {
+    PushValue(pv::pushdata4(value))
+}
+
+pub const NOP: Opcode = Operation(Normal(OP_NOP));
+pub const IF: Opcode = Operation(Control(OP_IF));
+pub const NOTIF: Opcode = Operation(Control(OP_NOTIF));
+pub const ELSE: Opcode = Operation(Control(OP_ELSE));
+pub const ENDIF: Opcode = Operation(Control(OP_ENDIF));
+pub const VERIFY: Opcode = Operation(Normal(OP_VERIFY));
+pub const RETURN: Opcode = Operation(Normal(OP_RETURN));
+pub const TOALTSTACK: Opcode = Operation(Normal(OP_TOALTSTACK));
+pub const FROMALTSTACK: Opcode = Operation(Normal(OP_FROMALTSTACK));
+pub const _2DROP: Opcode = Operation(Normal(OP_2DROP));
+pub const _2DUP: Opcode = Operation(Normal(OP_2DUP));
+pub const _3DUP: Opcode = Operation(Normal(OP_3DUP));
+pub const _2OVER: Opcode = Operation(Normal(OP_2OVER));
+pub const _2ROT: Opcode = Operation(Normal(OP_2ROT));
+pub const _2SWAP: Opcode = Operation(Normal(OP_2SWAP));
+pub const IFDUP: Opcode = Operation(Normal(OP_IFDUP));
+pub const DEPTH: Opcode = Operation(Normal(OP_DEPTH));
+pub const DROP: Opcode = Operation(Normal(OP_DROP));
+pub const DUP: Opcode = Operation(Normal(OP_DUP));
+pub const NIP: Opcode = Operation(Normal(OP_NIP));
+pub const OVER: Opcode = Operation(Normal(OP_NIP));
+pub const PICK: Opcode = Operation(Normal(OP_PICK));
+pub const ROLL: Opcode = Operation(Normal(OP_ROLL));
+pub const ROT: Opcode = Operation(Normal(OP_ROT));
+pub const SWAP: Opcode = Operation(Normal(OP_SWAP));
+pub const TUCK: Opcode = Operation(Normal(OP_TUCK));
+pub const SIZE: Opcode = Operation(Normal(OP_SIZE));
+pub const EQUAL: Opcode = Operation(Normal(OP_EQUAL));
+pub const EQUALVERIFY: Opcode = Operation(Normal(OP_EQUALVERIFY));
+pub const _1ADD: Opcode = Operation(Normal(OP_1ADD));
+pub const _1SUB: Opcode = Operation(Normal(OP_1SUB));
+pub const NEGATE: Opcode = Operation(Normal(OP_NEGATE));
+pub const ABS: Opcode = Operation(Normal(OP_ABS));
+pub const NOT: Opcode = Operation(Normal(OP_NOT));
+pub const _0NOTEQUAL: Opcode = Operation(Normal(OP_0NOTEQUAL));
+pub const ADD: Opcode = Operation(Normal(OP_ADD));
+pub const SUB: Opcode = Operation(Normal(OP_SUB));
+pub const BOOLAND: Opcode = Operation(Normal(OP_BOOLAND));
+pub const BOOLOR: Opcode = Operation(Normal(OP_BOOLOR));
+pub const NUMEQUAL: Opcode = Operation(Normal(OP_NUMEQUAL));
+pub const LESSTHAN: Opcode = Operation(Normal(OP_LESSTHAN));
+pub const GREATERTHAN: Opcode = Operation(Normal(OP_GREATERTHAN));
+pub const LESSTHANOREQUAL: Opcode = Operation(Normal(OP_LESSTHANOREQUAL));
+pub const GREATERTHANOREQUAL: Opcode = Operation(Normal(OP_GREATERTHANOREQUAL));
+pub const MIN: Opcode = Operation(Normal(OP_MIN));
+pub const MAX: Opcode = Operation(Normal(OP_MAX));
+pub const WITHIN: Opcode = Operation(Normal(OP_WITHIN));
+pub const RIPEMD160: Opcode = Operation(Normal(OP_RIPEMD160));
+pub const SHA1: Opcode = Operation(Normal(OP_SHA1));
+pub const SHA256: Opcode = Operation(Normal(OP_SHA256));
+pub const HASH160: Opcode = Operation(Normal(OP_HASH160));
+pub const HASH256: Opcode = Operation(Normal(OP_HASH256));
+pub const CHECKSIG: Opcode = Operation(Normal(OP_CHECKSIG));
+pub const CHECKSIGVERIFY: Opcode = Operation(Normal(OP_CHECKSIGVERIFY));
+pub const CHECKMULTISIG: Opcode = Operation(Normal(OP_CHECKMULTISIG));
+pub const CHECKMULTISIGVERIFY: Opcode = Operation(Normal(OP_CHECKMULTISIGVERIFY));
+pub const NOP1: Opcode = Operation(Normal(OP_NOP1));
+pub const CHECKLOCKTIMEVERIFY: Opcode = Operation(Normal(OP_CHECKLOCKTIMEVERIFY));
+pub const NOP3: Opcode = Operation(Normal(OP_NOP3));
+pub const NOP4: Opcode = Operation(Normal(OP_NOP4));
+pub const NOP5: Opcode = Operation(Normal(OP_NOP5));
+pub const NOP6: Opcode = Operation(Normal(OP_NOP6));
+pub const NOP7: Opcode = Operation(Normal(OP_NOP7));
+pub const NOP8: Opcode = Operation(Normal(OP_NOP8));
+pub const NOP9: Opcode = Operation(Normal(OP_NOP9));
+pub const NOP10: Opcode = Operation(Normal(OP_NOP10));
+
+pub mod bad {
+    use crate::{
+        pv,
+        script::{
+            Control::*,
+            Normal::*,
+            Opcode::{self, *},
+            Operation::*,
+        },
+    };
+
+    pub const RESERVED: Opcode = PushValue(pv::bad::RESERVED);
+    pub const VERIF: Opcode = Operation(Control(OP_VERIF));
+    pub const VERNOTIF: Opcode = Operation(Control(OP_VERNOTIF));
+    pub const VER: Opcode = Operation(Normal(OP_VER));
+    pub const RESERVED1: Opcode = Operation(Normal(OP_RESERVED1));
+    pub const RESERVED2: Opcode = Operation(Normal(OP_RESERVED2));
+}
+
+pub mod disabled {
+    use crate::script::{
+        Control::*,
+        Opcode::{self, *},
+        Operation::*,
+    };
+
+    pub const CAT: Opcode = Operation(Control(OP_CAT));
+    pub const SUBSTR: Opcode = Operation(Control(OP_SUBSTR));
+    pub const LEFT: Opcode = Operation(Control(OP_LEFT));
+    pub const RIGHT: Opcode = Operation(Control(OP_RIGHT));
+    pub const INVERT: Opcode = Operation(Control(OP_INVERT));
+    pub const AND: Opcode = Operation(Control(OP_AND));
+    pub const OR: Opcode = Operation(Control(OP_OR));
+    pub const XOR: Opcode = Operation(Control(OP_XOR));
+    pub const _2MUL: Opcode = Operation(Control(OP_2MUL));
+    pub const _2DIV: Opcode = Operation(Control(OP_2DIV));
+    pub const MUL: Opcode = Operation(Control(OP_MUL));
+    pub const DIV: Opcode = Operation(Control(OP_DIV));
+    pub const MOD: Opcode = Operation(Control(OP_MOD));
+    pub const LSHIFT: Opcode = Operation(Control(OP_LSHIFT));
+    pub const RSHIFT: Opcode = Operation(Control(OP_RSHIFT));
+    pub const CODESEPARATOR: Opcode = Operation(Control(OP_CODESEPARATOR));
+}

--- a/src/pv.rs
+++ b/src/pv.rs
@@ -1,0 +1,51 @@
+//! Convenience definitions for all push values.
+
+use crate::script::{
+    LargeValue::*,
+    PushValue::{self, *},
+    SmallValue::*,
+};
+
+pub const _0: PushValue = SmallValue(OP_0);
+pub const _1NEGATE: PushValue = SmallValue(OP_1NEGATE);
+pub const _1: PushValue = SmallValue(OP_1);
+pub const _2: PushValue = SmallValue(OP_2);
+pub const _3: PushValue = SmallValue(OP_3);
+pub const _4: PushValue = SmallValue(OP_4);
+pub const _5: PushValue = SmallValue(OP_5);
+pub const _6: PushValue = SmallValue(OP_6);
+pub const _7: PushValue = SmallValue(OP_7);
+pub const _8: PushValue = SmallValue(OP_8);
+pub const _9: PushValue = SmallValue(OP_9);
+pub const _10: PushValue = SmallValue(OP_10);
+pub const _11: PushValue = SmallValue(OP_11);
+pub const _12: PushValue = SmallValue(OP_12);
+pub const _13: PushValue = SmallValue(OP_13);
+pub const _14: PushValue = SmallValue(OP_14);
+pub const _15: PushValue = SmallValue(OP_15);
+pub const _16: PushValue = SmallValue(OP_16);
+
+pub fn pushdata_bytelength(value: Vec<u8>) -> PushValue {
+    LargeValue(PushdataBytelength(value))
+}
+
+pub fn pushdata1(value: Vec<u8>) -> PushValue {
+    LargeValue(OP_PUSHDATA1(value))
+}
+
+pub fn pushdata2(value: Vec<u8>) -> PushValue {
+    LargeValue(OP_PUSHDATA2(value))
+}
+
+pub fn pushdata4(value: Vec<u8>) -> PushValue {
+    LargeValue(OP_PUSHDATA4(value))
+}
+
+pub mod bad {
+    use crate::script::{
+        PushValue::{self, *},
+        SmallValue::*,
+    };
+
+    pub const RESERVED: PushValue = SmallValue(OP_RESERVED);
+}

--- a/src/script.rs
+++ b/src/script.rs
@@ -7,11 +7,11 @@ use super::script_error::*;
 pub const MAX_SCRIPT_ELEMENT_SIZE: usize = 520; // bytes
 
 /// Maximum script length in bytes
-pub const MAX_SCRIPT_SIZE: usize = 10000;
+pub const MAX_SCRIPT_SIZE: usize = 10_000;
 
 // Threshold for lock_time: below this value it is interpreted as block number,
 // otherwise as UNIX timestamp.
-pub const LOCKTIME_THRESHOLD: i64 = 500000000; // Tue Nov  5 00:53:20 1985 UTC
+pub const LOCKTIME_THRESHOLD: i64 = 500_000_000; // Tue Nov  5 00:53:20 1985 UTC
 
 /** Script opcodes */
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]

--- a/src/script.rs
+++ b/src/script.rs
@@ -14,21 +14,62 @@ pub const MAX_SCRIPT_SIZE: usize = 10_000;
 pub const LOCKTIME_THRESHOLD: i64 = 500_000_000; // Tue Nov  5 00:53:20 1985 UTC
 
 /** Script opcodes */
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Opcode {
     PushValue(PushValue),
     Operation(Operation),
 }
 
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum LargeValue {
+    // push value
+    PushdataBytelength(Vec<u8>),
+    OP_PUSHDATA1(Vec<u8>),
+    OP_PUSHDATA2(Vec<u8>),
+    OP_PUSHDATA4(Vec<u8>),
+}
+
+use LargeValue::*;
+
+impl LargeValue {
+    pub fn value(&self) -> Vec<u8> {
+        match self {
+            PushdataBytelength(v) | OP_PUSHDATA1(v) | OP_PUSHDATA2(v) | OP_PUSHDATA4(v) => {
+                v.clone()
+            }
+        }
+    }
+
+    pub fn is_minimal_push(&self) -> bool {
+        match self {
+            PushdataBytelength(data) => match data.len() {
+                1 => data[0] != 0x81 && (data[0] < 1 || 16 < data[0]),
+                _ => true,
+            },
+            OP_PUSHDATA1(data) => 0x4c <= data.len(),
+            OP_PUSHDATA2(data) => 0x100 <= data.len(),
+            OP_PUSHDATA4(data) => 0x10000 <= data.len(),
+        }
+    }
+}
+
+impl From<LargeValue> for u8 {
+    fn from(lv: LargeValue) -> Self {
+        match lv {
+            PushdataBytelength(value) => value.len().try_into().unwrap(),
+            OP_PUSHDATA1(_) => 0x4c,
+            OP_PUSHDATA2(_) => 0x4d,
+            OP_PUSHDATA4(_) => 0x4e,
+        }
+    }
+}
+
+enum_from_primitive! {
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 #[repr(u8)]
-pub enum PushValue {
+pub enum SmallValue {
     // push value
     OP_0 = 0x00,
-    PushdataBytelength(u8),
-    OP_PUSHDATA1 = 0x4c,
-    OP_PUSHDATA2 = 0x4d,
-    OP_PUSHDATA4 = 0x4e,
     OP_1NEGATE = 0x4f,
     OP_RESERVED = 0x50,
     OP_1 = 0x51,
@@ -48,8 +89,49 @@ pub enum PushValue {
     OP_15 = 0x5f,
     OP_16 = 0x60,
 }
+}
 
-use PushValue::*;
+use SmallValue::*;
+
+impl SmallValue {
+    pub fn value(&self) -> Option<Vec<u8>> {
+        match self {
+            OP_0 => Some(vec![]),
+            OP_1NEGATE => Some(vec![0x81]),
+            OP_RESERVED => None,
+            _ => Some(vec![u8::from(*self) - (u8::from(OP_1) - 1)]),
+        }
+    }
+}
+
+impl From<SmallValue> for u8 {
+    fn from(value: SmallValue) -> Self {
+        // This is how you get the discriminant, but using `as` everywhere is too much code smell
+        value as u8
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum PushValue {
+    SmallValue(SmallValue),
+    LargeValue(LargeValue),
+}
+
+impl PushValue {
+    pub fn value(&self) -> Option<Vec<u8>> {
+        match self {
+            PushValue::LargeValue(pv) => Some(pv.value()),
+            PushValue::SmallValue(pv) => pv.value(),
+        }
+    }
+
+    pub fn is_minimal_push(&self) -> bool {
+        match self {
+            PushValue::LargeValue(lv) => lv.is_minimal_push(),
+            PushValue::SmallValue(_) => true,
+        }
+    }
+}
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Operation {
@@ -204,13 +286,6 @@ impl From<Opcode> for u8 {
     }
 }
 
-impl From<u8> for Opcode {
-    fn from(value: u8) -> Self {
-        PushValue::try_from(value)
-            .map_or(Opcode::Operation(Operation::from(value)), Opcode::PushValue)
-    }
-}
-
 impl From<Operation> for u8 {
     fn from(value: Operation) -> Self {
         match value {
@@ -233,66 +308,8 @@ impl From<u8> for Operation {
 impl From<PushValue> for u8 {
     fn from(value: PushValue) -> Self {
         match value {
-            OP_0 => 0x00,
-            PushdataBytelength(byte) => byte,
-            OP_PUSHDATA1 => 0x4c,
-            OP_PUSHDATA2 => 0x4d,
-            OP_PUSHDATA4 => 0x4e,
-            OP_1NEGATE => 0x4f,
-            OP_RESERVED => 0x50,
-            OP_1 => 0x51,
-            OP_2 => 0x52,
-            OP_3 => 0x53,
-            OP_4 => 0x54,
-            OP_5 => 0x55,
-            OP_6 => 0x56,
-            OP_7 => 0x57,
-            OP_8 => 0x58,
-            OP_9 => 0x59,
-            OP_10 => 0x5a,
-            OP_11 => 0x5b,
-            OP_12 => 0x5c,
-            OP_13 => 0x5d,
-            OP_14 => 0x5e,
-            OP_15 => 0x5f,
-            OP_16 => 0x60,
-        }
-    }
-}
-
-impl TryFrom<u8> for PushValue {
-    type Error = ();
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0x00 => Ok(OP_0),
-            0x4c => Ok(OP_PUSHDATA1),
-            0x4d => Ok(OP_PUSHDATA2),
-            0x4e => Ok(OP_PUSHDATA4),
-            0x4f => Ok(OP_1NEGATE),
-            0x50 => Ok(OP_RESERVED),
-            0x51 => Ok(OP_1),
-            0x52 => Ok(OP_2),
-            0x53 => Ok(OP_3),
-            0x54 => Ok(OP_4),
-            0x55 => Ok(OP_5),
-            0x56 => Ok(OP_6),
-            0x57 => Ok(OP_7),
-            0x58 => Ok(OP_8),
-            0x59 => Ok(OP_9),
-            0x5a => Ok(OP_10),
-            0x5b => Ok(OP_11),
-            0x5c => Ok(OP_12),
-            0x5d => Ok(OP_13),
-            0x5e => Ok(OP_14),
-            0x5f => Ok(OP_15),
-            0x60 => Ok(OP_16),
-            _ => {
-                if value <= 0x60 {
-                    Ok(PushdataBytelength(value))
-                } else {
-                    Err(())
-                }
-            }
+            PushValue::SmallValue(pv) => pv.into(),
+            PushValue::LargeValue(pv) => pv.into(),
         }
     }
 }
@@ -425,8 +442,16 @@ pub fn serialize_num(value: i64) -> Vec<u8> {
 pub struct Script<'a>(pub &'a [u8]);
 
 impl Script<'_> {
-    pub fn get_op(script: &[u8]) -> Result<(Opcode, &[u8]), ScriptError> {
-        Self::get_op2(script).map(|(op, _, remainder)| (op, remainder))
+    pub fn parse(&self) -> Result<Vec<Opcode>, ScriptError> {
+        let mut pc = self.0;
+        let mut result = vec![];
+        while !pc.is_empty() {
+            Self::get_op(pc).map(|(op, new_pc)| {
+                pc = new_pc;
+                result.push(op)
+            })?;
+        }
+        Ok(result)
     }
 
     fn split_value(script: &[u8], needed_bytes: usize) -> Result<(&[u8], &[u8]), ScriptError> {
@@ -451,28 +476,54 @@ impl Script<'_> {
         })
     }
 
-    pub fn get_op2(script: &[u8]) -> Result<(Opcode, &[u8], &[u8]), ScriptError> {
+    pub fn get_lv(script: &[u8]) -> Result<Option<(LargeValue, &[u8])>, ScriptError> {
         match script.split_first() {
             None => Err(ScriptError::ReadError {
                 expected_bytes: 1,
                 available_bytes: 0,
             }),
-            Some((leading_byte, script)) => match Opcode::from(*leading_byte) {
-                op @ Opcode::PushValue(pv) => match pv {
-                    OP_PUSHDATA1 => Script::split_tagged_value(script, 1),
-                    OP_PUSHDATA2 => Script::split_tagged_value(script, 2),
-                    OP_PUSHDATA4 => Script::split_tagged_value(script, 4),
-                    PushdataBytelength(size_byte) => Script::split_value(script, size_byte.into()),
-                    _ => Ok((&[][..], script)),
+            Some((leading_byte, script)) => match leading_byte {
+                0x4c => Self::split_tagged_value(script, 1)
+                    .map(|(v, script)| Some((OP_PUSHDATA1(v.to_vec()), script))),
+                0x4d => Self::split_tagged_value(script, 2)
+                    .map(|(v, script)| Some((OP_PUSHDATA2(v.to_vec()), script))),
+                0x4e => Self::split_tagged_value(script, 4)
+                    .map(|(v, script)| Some((OP_PUSHDATA4(v.to_vec()), script))),
+                _ => {
+                    if 0x01 <= *leading_byte && *leading_byte < 0x4c {
+                        Self::split_value(script, (*leading_byte).into())
+                            .map(|(v, script)| Some((PushdataBytelength(v.to_vec()), script)))
+                    } else {
+                        Ok(None)
+                    }
                 }
-                .map(|(value, script)| (op, value, script)),
-                op => Ok((op, &[], script)),
             },
         }
     }
 
+    pub fn get_op(script: &[u8]) -> Result<(Opcode, &[u8]), ScriptError> {
+        Self::get_lv(script).and_then(|r| {
+            r.map_or(
+                match script.split_first() {
+                    None => Err(ScriptError::ReadError {
+                        expected_bytes: 1,
+                        available_bytes: 0,
+                    }),
+                    Some((leading_byte, script)) => Ok((
+                        SmallValue::from_u8(*leading_byte)
+                            .map_or(Opcode::Operation(Operation::from(*leading_byte)), |sv| {
+                                Opcode::PushValue(PushValue::SmallValue(sv))
+                            }),
+                        script,
+                    )),
+                },
+                |(v, script)| Ok((Opcode::PushValue(PushValue::LargeValue(v)), script)),
+            )
+        })
+    }
+
     /** Encode/decode small integers: */
-    pub fn decode_op_n(opcode: PushValue) -> u32 {
+    pub fn decode_op_n(opcode: SmallValue) -> u32 {
         if opcode == OP_0 {
             return 0;
         }
@@ -501,7 +552,7 @@ impl Script<'_> {
                     n += 1;
                 } else if op == OP_CHECKMULTISIG || op == OP_CHECKMULTISIGVERIFY {
                     match last_opcode {
-                        Some(Opcode::PushValue(pv)) => {
+                        Some(Opcode::PushValue(PushValue::SmallValue(pv))) => {
                             if accurate && pv >= OP_1 && pv <= OP_16 {
                                 n += Self::decode_op_n(pv);
                             } else {
@@ -519,10 +570,13 @@ impl Script<'_> {
 
     /// Returns true iff this script is P2SH.
     pub fn is_pay_to_script_hash(&self) -> bool {
-        self.0.len() == 23
-            && self.0[0] == OP_HASH160.into()
-            && self.0[1] == 0x14
-            && self.0[22] == OP_EQUAL.into()
+        self.parse().map_or(false, |ops| match &ops[..] {
+            [ Opcode::Operation(Operation::Normal(OP_HASH160)),
+              Opcode::PushValue(PushValue::LargeValue(PushdataBytelength(v))),
+              Opcode::Operation(Operation::Normal(OP_EQUAL))
+            ] => v.len() == 0x14,
+            _ => false
+        })
     }
 
     /// Called by `IsStandardTx` and P2SH/BIP62 VerifyScript (which makes it consensus-critical).

--- a/src/script_error.rs
+++ b/src/script_error.rs
@@ -1,3 +1,15 @@
+use secp256k1;
+
+/// Things that can go wrong when constructing a `HashType` from bit flags.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum InvalidHashType {
+    /// Either or both of the two least-significant bits must be set.
+    UnknownSignedOutputs,
+    /// With v5 transactions, bits other than those specified for `HashType` must be 0. The `i32`
+    /// includes only the bits that are undefined by `HashType`.
+    ExtraBitsSet(i32),
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ScriptNumError {
     NonMinimalEncoding,
@@ -39,8 +51,8 @@ pub enum ScriptError {
     UnsatisfiedLockTime,
 
     // BIP62
-    SigHashType,
-    SigDER,
+    SigHashType(Option<InvalidHashType>),
+    SigDER(Option<secp256k1::Error>),
     MinimalData,
     SigPushOnly,
     SigHighS,
@@ -51,6 +63,7 @@ pub enum ScriptError {
     // softfork safeness
     DiscourageUpgradableNOPs,
 
+    // extensions (these don’t exist in C++, and thus map to `UnknownError`)
     ReadError {
         expected_bytes: usize,
         available_bytes: usize,

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -318,10 +318,10 @@ mod tests {
             } => {
                 assert!(
                     identical_states.len() == 6
-                        && state.stack().size() == 4
-                        && state.altstack().empty()
+                        && state.stack().len() == 4
+                        && state.altstack().is_empty()
                         && state.op_count() == 2
-                        && state.vexec().empty()
+                        && state.vexec().is_empty()
                 );
             }
             _ => {


### PR DESCRIPTION
This splits `Operation` into three separate enums – `Control` (for
if/else, which get executed regardless of `vexec` and disabled
operations, which always fail, regardless of `vexec`), `Normal`, for
operations that respect `vexec`, and `Unknown` for undefined opcodes
which only fail if they’re on an active branch. This is done so that the
evaluator can be split on the same lines.

It also integrates the values with the `PushValue` opcodes.

And it exposes two modules (`op` and `pv`) to allow a separation between internal opcode structure for the implementation and the interface consumers (PCZT, etc.) use.

This depends on #221 and #222.