### PR TITLE
Add script serialization & patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ path = "src/lib.rs"
 
 [features]
 external-secp = []
-test-dependencies = ["dep:hex"]
+test-dependencies = ["dep:hex", "dep:lazy_static"]
 
 [dependencies]
 bitflags = "2.8"
@@ -81,6 +81,7 @@ bounded-vec = "0.9"
 enum_primitive = "0.1"
 hex = { version = ">= 0.4.3", optional = true } # See Note [explicit >= version requirements]
 itertools = "0.14"
+lazy_static = { version = "1.5.0", optional = true }
 ripemd = "0.1"
 # This needs to match the version used by ECC crates (which are being used in
 # Zebra).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod cxx;
 mod external;
 pub mod interpreter;
 pub mod op;
+pub mod pattern;
 pub mod pv;
 mod script;
 pub mod script_error;
@@ -312,11 +313,15 @@ impl<T: ZcashScript, U: ZcashScript> ZcashScript for ComparisonInterpreter<T, U>
 pub mod testing {
     use crate::{
         interpreter::{State, StepFn, VerificationFlags},
-        script::{self, Operation, Script},
+        pattern::{check_multisig, pay_to_script_hash, push_num, push_script},
+        pv,
+        script::{self, Opcode, Operation, Script},
         script_error::ScriptError,
+        signature::HashType,
         test_vectors::TestVector,
         zcash_script, Error,
     };
+    use hex::FromHex;
 
     /// Ensures that flags represent a supported state. This avoids crashes in the C++ code, which
     /// break various tests.
@@ -360,6 +365,38 @@ pub mod testing {
         }
     }
 
+    lazy_static::lazy_static! {
+        pub static ref REDEEM_SCRIPT: Vec<Opcode> = check_multisig(
+            2,
+            &[
+                &<[u8; 0x21]>::from_hex("03b2cc71d23eb30020a4893982a1e2d352da0d20ee657fa02901c432758909ed8f").expect("valid key"),
+                &<[u8; 0x21]>::from_hex("029d1e9a9354c0d2aee9ffd0f0cea6c39bbf98c4066cf143115ba2279d0ba7dabe").expect("valid key"),
+                &<[u8; 0x21]>::from_hex("03e32096b63fd57f3308149d238dcbb24d8d28aad95c0e4e74e3e5e6a11b61bcc4").expect("valid key")
+            ],
+            false);
+        pub static ref SCRIPT_PUBKEY: Vec<u8> = Script::serialize(&pay_to_script_hash(&REDEEM_SCRIPT));
+        pub static ref SCRIPT_SIG: Vec<u8> = Script::serialize(&[
+            push_num(0),
+            pv::push_value(&<[u8; 0x48]>::from_hex("3045022100d2ab3e6258fe244fa442cfb38f6cef9ac9a18c54e70b2f508e83fa87e20d040502200eead947521de943831d07a350e45af8e36c2166984a8636f0a8811ff03ed09401").expect("valid sig")).expect("fits into a PushValue"),
+            pv::push_value(&<[u8; 0x47]>::from_hex("3044022013e15d865010c257eef133064ef69a780b4bc7ebe6eda367504e806614f940c3022062fdbc8c2d049f91db2042d6c9771de6f1ef0b3b1fea76c1ab5542e44ed29ed801").expect("valid sig")).expect("fits into a PushValue"),
+            push_script(&REDEEM_SCRIPT).expect("fits into a PushValue"),
+        ].map(Opcode::PushValue));
+    }
+
+    pub fn sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
+        <[u8; 32]>::from_hex("e8c7bdac77f6bb1f3aba2eaa1fada551a9c8b3b5ecd1ef86e6e58a5f1aab952c")
+            .ok()
+    }
+
+    pub fn invalid_sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
+        <[u8; 32]>::from_hex("08c7bdac77f6bb1f3aba2eaa1fada551a9c8b3b5ecd1ef86e6e58a5f1aab952c")
+            .ok()
+    }
+
+    pub fn missing_sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
+        None
+    }
+
     pub fn run_test_vector(
         tv: &TestVector,
         try_normalized_error: bool,
@@ -393,39 +430,21 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
-    use hex::FromHex;
     use proptest::prelude::{prop, prop_assert_eq, proptest, ProptestConfig};
 
     use super::{
         check_verify_callback, normalize_error, rust_interpreter,
         test_vectors::test_vectors,
-        testing::{repair_flags, run_test_vector, OVERFLOW_SCRIPT_SIZE},
+        testing::{
+            invalid_sighash, missing_sighash, repair_flags, run_test_vector, sighash,
+            OVERFLOW_SCRIPT_SIZE, SCRIPT_PUBKEY, SCRIPT_SIG,
+        },
         CxxInterpreter, Error, ZcashScript,
     };
     use crate::{
         interpreter::{CallbackTransactionSignatureChecker, VerificationFlags},
         script_error::ScriptError,
-        signature::HashType,
     };
-
-    lazy_static::lazy_static! {
-        pub static ref SCRIPT_PUBKEY: Vec<u8> = <Vec<u8>>::from_hex("a914c117756dcbe144a12a7c33a77cfa81aa5aeeb38187").unwrap();
-        pub static ref SCRIPT_SIG: Vec<u8> = <Vec<u8>>::from_hex("00483045022100d2ab3e6258fe244fa442cfb38f6cef9ac9a18c54e70b2f508e83fa87e20d040502200eead947521de943831d07a350e45af8e36c2166984a8636f0a8811ff03ed09401473044022013e15d865010c257eef133064ef69a780b4bc7ebe6eda367504e806614f940c3022062fdbc8c2d049f91db2042d6c9771de6f1ef0b3b1fea76c1ab5542e44ed29ed8014c69522103b2cc71d23eb30020a4893982a1e2d352da0d20ee657fa02901c432758909ed8f21029d1e9a9354c0d2aee9ffd0f0cea6c39bbf98c4066cf143115ba2279d0ba7dabe2103e32096b63fd57f3308149d238dcbb24d8d28aad95c0e4e74e3e5e6a11b61bcc453ae").expect("Block bytes are in valid hex representation");
-    }
-
-    fn sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
-        <[u8; 32]>::from_hex("e8c7bdac77f6bb1f3aba2eaa1fada551a9c8b3b5ecd1ef86e6e58a5f1aab952c")
-            .ok()
-    }
-
-    fn invalid_sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
-        <[u8; 32]>::from_hex("08c7bdac77f6bb1f3aba2eaa1fada551a9c8b3b5ecd1ef86e6e58a5f1aab952c")
-            .ok()
-    }
-
-    fn missing_sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
-        None
-    }
 
     #[test]
     fn it_works() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ pub mod testing {
                 &<[u8; 0x21]>::from_hex("029d1e9a9354c0d2aee9ffd0f0cea6c39bbf98c4066cf143115ba2279d0ba7dabe").expect("valid key"),
                 &<[u8; 0x21]>::from_hex("03e32096b63fd57f3308149d238dcbb24d8d28aad95c0e4e74e3e5e6a11b61bcc4").expect("valid key")
             ],
-            false);
+            false).expect("all keys are valid and there’s not more than 20 of them");
         /// The scriptPubkey used for the static test case.
         pub static ref SCRIPT_PUBKEY: Vec<u8> = Script::serialize(&pay_to_script_hash(&REDEEM_SCRIPT));
         /// The scriptSig used for the static test case.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,6 +366,7 @@ pub mod testing {
     }
 
     lazy_static::lazy_static! {
+        /// The P2SH redeem script used for the static test case.
         pub static ref REDEEM_SCRIPT: Vec<Opcode> = check_multisig(
             2,
             &[
@@ -374,7 +375,9 @@ pub mod testing {
                 &<[u8; 0x21]>::from_hex("03e32096b63fd57f3308149d238dcbb24d8d28aad95c0e4e74e3e5e6a11b61bcc4").expect("valid key")
             ],
             false);
+        /// The scriptPubkey used for the static test case.
         pub static ref SCRIPT_PUBKEY: Vec<u8> = Script::serialize(&pay_to_script_hash(&REDEEM_SCRIPT));
+        /// The scriptSig used for the static test case.
         pub static ref SCRIPT_SIG: Vec<u8> = Script::serialize(&[
             push_num(0),
             pv::push_value(&<[u8; 0x48]>::from_hex("3045022100d2ab3e6258fe244fa442cfb38f6cef9ac9a18c54e70b2f508e83fa87e20d040502200eead947521de943831d07a350e45af8e36c2166984a8636f0a8811ff03ed09401").expect("valid sig")).expect("fits into a PushValue"),
@@ -383,16 +386,19 @@ pub mod testing {
         ].map(Opcode::PushValue));
     }
 
+    /// The correct sighash for the static test case.
     pub fn sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
         <[u8; 32]>::from_hex("e8c7bdac77f6bb1f3aba2eaa1fada551a9c8b3b5ecd1ef86e6e58a5f1aab952c")
             .ok()
     }
 
+    /// An incorrect sighash for the static test case – for checking failure cases.
     pub fn invalid_sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
         <[u8; 32]>::from_hex("08c7bdac77f6bb1f3aba2eaa1fada551a9c8b3b5ecd1ef86e6e58a5f1aab952c")
             .ok()
     }
 
+    /// A callback that returns no sighash at all – another failure case.
     pub fn missing_sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
         None
     }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,0 +1,453 @@
+//! Reusable bits of scripts, to avoid writing hex strings.
+//!
+//! Much of this comes from https://gist.github.com/str4d/9d80f1b60e6787310897044502cb025b – the
+//! corresponding definitions here have a “label” tag in the documentation that indicates the result
+//! of `label_script` that they map to.
+//!
+//! Zcash Script doesn’t have a real type system, but many of these are annotated with some
+//! indication of the type. Being scripts with holes, the types are more complicated than those
+//! listed with the opcodes in interpreter.rs. Here’s the decoder ring:
+
+//! * `Bool`, `PubKey`, `Signature`, and other capitalized WordsSmashedTogether – a individual stack
+//!   value, with a particular shape
+//! * `[]` – a comma-separated sequence of stack values
+//! * `+` – a concatenation of stack sequences (useful with type variables that represent sequences)
+//! * `*` – repetition `n*Signature` is a sequence of `n` Signature`s
+//! * `->` – input on the left, output on the right
+//! * `∪` – a union of stack sequences (in negative position, this is “existential”, and “universal”
+//!   in positive position)
+//! * `💥` – terminates evaluation, if followed by `?`, it _may_ terminate evaluation
+//! * vars – identifiers in the Rust function signature, indicates where those values are used. In
+//!   the case of identifiers that represent `[Opcode]`, an occurrence in negative position
+//!   represents the input type of that script, and an occurence in positive position represents the
+//!   output type of that script. Identifiers that don’t show up in the rust function signature
+//!   represent type variables – they are the same type in each occurrence.
+//! * `_` – any type, each occurrence can represent a different type
+
+use ripemd::Ripemd160;
+use sha2::{Digest, Sha256};
+
+use crate::{
+    op, pv,
+    script::{
+        self,
+        Opcode::{self, PushValue},
+        Script,
+    },
+};
+
+/// Pushes a value onto the stack that indicates whether the stack was previously empty.
+///
+/// type: `[] -> [Bool]`
+pub const EMPTY_STACK_CHECK: [Opcode; 3] = [op::DEPTH, op::_0, op::EQUAL];
+
+/// Pushes a value onto the stack, then immediately drops it.
+///
+/// type: `[] -> []`
+pub fn ignored_value(v: script::PushValue) -> [Opcode; 2] {
+    [PushValue(v), op::DROP]
+}
+
+// abstractions
+
+/// Holds the two branches of a conditional, without the condition.
+///
+/// type: `(thn ∪ els) + [Bool] -> (thn ∪ els)`
+pub fn branch(thn: &[Opcode], els: &[Opcode]) -> Vec<Opcode> {
+    [&[op::IF], thn, &[op::ELSE], els, &[op::ENDIF]].concat()
+}
+
+/// Like `branch`, but also holds the conditional.
+///
+/// Example: `if_else(size_check(20), [], [op::RETURN])`
+///
+/// type: `((thn ∪ els) - y) + x -> (y - (thn ∪ els)) + (thn ∪ els)`
+///     where cond: `x -> y + [Bool]`
+pub fn if_else(cond: &[Opcode], thn: &[Opcode], els: &[Opcode]) -> Vec<Opcode> {
+    let mut vec = cond.to_vec();
+    vec.extend(branch(thn, els));
+    vec
+}
+
+/// Performs a `sig_count`-of-`pks.len()` multisig.
+///
+/// if `verify`
+///   type: `sig_count*Signature -> 💥?`
+///   type: `sig_count*Signature -> [Bool]`
+pub fn check_multisig(sig_count: u8, pks: &[&[u8]], verify: bool) -> Vec<Opcode> {
+    [
+        &[PushValue(push_num(sig_count.into()))],
+        &pks.iter()
+            .map(|pk| PushValue(pv::push_value(pk).expect("each pubkey is no more than 65 bytes")))
+            .collect::<Vec<Opcode>>()[..],
+        &[
+            PushValue(push_num(
+                pks.len()
+                    .try_into()
+                    .expect("Should not be more than 20 pubkeys"),
+            )),
+            if verify {
+                op::CHECKMULTISIGVERIFY
+            } else {
+                op::CHECKMULTISIG
+            },
+        ],
+    ]
+    .concat()
+}
+
+/// Checks equality against some constant value.
+///
+/// if `verify`
+///   type: `[_] -> 💥?`
+///   type: `[_] -> [Bool]`
+pub fn equals(expected: script::PushValue, verify: bool) -> [Opcode; 2] {
+    [
+        PushValue(expected),
+        if verify { op::EQUALVERIFY } else { op::EQUAL },
+    ]
+}
+
+/// Checks a signature against the provided pubkey.
+///
+/// if `verify`
+///   type: `[Signature] -> 💥?`
+///   type: `[Signature] -> [Bool]`
+pub fn check_sig(pubkey: &[u8], verify: bool) -> [Opcode; 2] {
+    [
+        PushValue(pv::push_value(pubkey).expect("each pubkey is no more than 65 bytes")),
+        if verify {
+            op::CHECKSIGVERIFY
+        } else {
+            op::CHECKSIG
+        },
+    ]
+}
+
+/// Checks that the top of the stack has exactly the expected size.
+///
+/// if `verify`
+///   type: `[a] -> [a] + 💥?`
+///   type: `[a] -> [a, Bool]`
+pub fn size_check(expected: u32, verify: bool) -> Vec<Opcode> {
+    [&[op::SIZE], &equals(push_num(expected.into()), verify)[..]].concat()
+}
+
+/// “CLTV”
+///
+/// type: `[] -> [lt] + 💥?`
+pub fn check_lock_time_verify(lt: u32) -> [Opcode; 3] {
+    [
+        PushValue(push_num(lt.into())),
+        op::CHECKLOCKTIMEVERIFY,
+        op::DROP,
+    ]
+}
+
+/// Produce a minimal `PushValue` that encodes the provided number.
+pub fn push_num(n: i64) -> script::PushValue {
+    pv::push_value(&script::serialize_num(n)).expect("all i64 can be encoded as `PushValue`")
+}
+
+/// Produce a minimal `PushValue` that encodes the provided script. This is particularly useful with
+/// P2SH.
+pub fn push_script(script: &[Opcode]) -> Option<script::PushValue> {
+    pv::push_value(&Script::serialize(script))
+}
+
+/// Creates a `PushValue` from a 20-byte value (basically, RipeMD160 and other hashes).
+///
+/// __TODO__: Once const_generic_exprs lands, this should become `push_array<N>(a: &[u8; N])` with
+///           `N` bounded by `MAX_SCRIPT_ELEMENT_SIZE`.
+pub fn push_160b_hash(hash: &[u8; 20]) -> script::PushValue {
+    pv::push_value(hash).expect("20 is a valid data size")
+}
+
+/// Creates a `PushValue` from a 32-byte value (basically, SHA-256 and other hashes).
+///
+/// __TODO__: Once const_generic_exprs lands, this should become `push_array<N>(a: &[u8; N])` with
+///           `N` bounded by `MAX_SCRIPT_ELEMENT_SIZE`.
+pub fn push_256b_hash(hash: &[u8; 32]) -> script::PushValue {
+    pv::push_value(hash).expect("32 is a valid data size")
+}
+
+/// P2PK
+///
+/// label: Pay-to-(compressed-)pubkey inside P2SH
+///
+/// type: `[Signature] -> [Bool]`
+pub fn pay_to_pubkey(pubkey: &[u8]) -> [Opcode; 2] {
+    check_sig(pubkey, false)
+}
+
+/// P2PKH
+///
+/// type: `[Signature, PubKey] -> [Bool] ∪  💥`
+pub fn pay_to_pubkey_hash(pk: &[u8]) -> Vec<Opcode> {
+    [
+        &[op::DUP, op::HASH160],
+        &equals(
+            push_160b_hash(&Ripemd160::digest(Sha256::digest(pk)).into()),
+            true,
+        )[..],
+        &[op::CHECKSIG],
+    ]
+    .concat()
+}
+
+/// P2SH
+///
+/// type: `[_] -> [Bool]`
+pub fn pay_to_script_hash(redeem_script: &[Opcode]) -> Vec<Opcode> {
+    [
+        &[op::HASH160],
+        &equals(
+            push_160b_hash(
+                &Ripemd160::digest(Sha256::digest(Script::serialize(redeem_script))).into(),
+            ),
+            false,
+        )[..],
+    ]
+    .concat()
+}
+
+/// multisig with ignored value and empty stack check
+///
+/// label: 2-of-3 multisig with compressed pubkeys, a 4-byte ignored data value, and an empty stack
+///   check
+///
+/// type: `n*Signature -> [Bool] ∪  💥`
+pub fn check_multisig_empty(n: u8, x: &[&[u8]], ignored: script::PushValue) -> Vec<Opcode> {
+    [
+        &check_multisig(n, x, true),
+        &ignored_value(ignored)[..],
+        &EMPTY_STACK_CHECK,
+    ]
+    .concat()
+}
+
+/// Combined multisig
+///
+/// 1-of-3 and 2-of-2 combined multisig with compressed pubkeys
+///
+/// type: m*Signature + n*Signature -> [Bool] ∪  💥
+pub fn combined_multisig(m: u8, x: &[&[u8]], n: u8, y: &[&[u8]]) -> Vec<Opcode> {
+    [
+        &check_multisig(m, x, true)[..],
+        &check_multisig(n, y, false)[..],
+    ]
+    .concat()
+}
+
+/// P2PKH with an ignored value
+///
+/// label:
+/// - P2PKH inside P2SH with a 32-byte ignored data value
+/// - P2PKH inside P2SH with a zero-value placeholder ignored data value
+///
+/// type: [Signature, PubKey] -> [Bool] ∪  💥
+pub fn p2pkh_ignored(ignored: script::PushValue, pk: &[u8]) -> Vec<Opcode> {
+    [&ignored_value(ignored)[..], &pay_to_pubkey_hash(pk)].concat()
+}
+
+/// P2PK with ignored value and empty stack check
+///
+/// label: Pay-to-(compressed-)pubkey inside P2SH with an empty stack check
+///
+/// type: `Signature -> [Bool] ∪  💥`
+pub fn p2pk_empty(recipient_pk: &[u8], ignored: script::PushValue) -> Vec<Opcode> {
+    [
+        &check_sig(recipient_pk, true)[..],
+        &ignored_value(ignored)[..],
+        &EMPTY_STACK_CHECK,
+    ]
+    .concat()
+}
+
+/// Hash160 HTLC
+pub fn hash160_htlc(
+    lt: u32,
+    sender_pk: &[u8],
+    recipient_hash: &[u8; 20],
+    recipient_pk: &[u8],
+) -> Vec<Opcode> {
+    branch(
+        &[
+            &check_lock_time_verify(lt)[..],
+            &check_sig(sender_pk, false)[..],
+        ]
+        .concat(),
+        &[
+            &[op::HASH160],
+            &equals(push_160b_hash(recipient_hash), true)[..],
+            &check_sig(recipient_pk, false)[..],
+        ]
+        .concat(),
+    )
+}
+
+/// Hash160 HTLC with size check
+pub fn hash160_htlc_size_check(
+    lt: u32,
+    sender_pk: &[u8],
+    recipient_hash: &[u8; 20],
+    recipient_pk: &[u8],
+) -> Vec<Opcode> {
+    branch(
+        &[
+            &check_lock_time_verify(lt)[..],
+            &check_sig(sender_pk, false)[..],
+        ]
+        .concat(),
+        &[
+            &size_check(20, true)[..],
+            &[op::HASH160],
+            &equals(push_160b_hash(recipient_hash), true)[..],
+            &check_sig(recipient_pk, false)[..],
+        ]
+        .concat(),
+    )
+}
+
+/// Hash160 HTLC
+pub fn hash160_htlc_neg(
+    lt: u32,
+    sender_pk: &[u8],
+    recipient_hash: &[u8; 20],
+    recipient_pk: &[u8],
+) -> Vec<Opcode> {
+    branch(
+        &[
+            &[op::HASH160],
+            &equals(push_160b_hash(recipient_hash), true)[..],
+            &pay_to_pubkey_hash(recipient_pk)[..],
+        ]
+        .concat(),
+        &[
+            &check_lock_time_verify(lt)[..],
+            &pay_to_pubkey_hash(sender_pk)[..],
+        ]
+        .concat(),
+    )
+}
+
+/// SHA-256 HTLC
+pub fn sha256_htlc(
+    lt: u32,
+    sender_pk: &[u8],
+    recipient_sha: &[u8; 32],
+    recipient_pk: &[u8],
+) -> Vec<Opcode> {
+    branch(
+        &[
+            &check_lock_time_verify(lt)[..],
+            &check_sig(sender_pk, false)[..],
+        ]
+        .concat(),
+        &[
+            &[op::SHA256],
+            &equals(push_256b_hash(recipient_sha), true)[..],
+            &check_sig(recipient_pk, false)[..],
+        ]
+        .concat(),
+    )
+}
+
+/// SHA-256 HTLC
+///
+/// label:
+/// - SHA-256 HTLC (2-byte CLTV)
+/// - SHA-256 HTLC (3-byte CLTV)
+pub fn sha256_htlc_neg(
+    lt: u32,
+    sender_pk: &[u8],
+    recipient_sha: &[u8; 32],
+    recipient_pk: &[u8],
+) -> Vec<Opcode> {
+    branch(
+        &[
+            &[op::SHA256],
+            &equals(push_256b_hash(recipient_sha), true)[..],
+            &pay_to_pubkey_hash(recipient_pk)[..],
+        ]
+        .concat(),
+        &[
+            &check_lock_time_verify(lt)[..],
+            &pay_to_pubkey_hash(sender_pk)[..],
+        ]
+        .concat(),
+    )
+}
+
+/// SHA-256 HTLC with size check
+pub fn sha256_htlc_size_check(
+    lt: u32,
+    sender_pk: &[u8],
+    recipient_sha: &[u8; 32],
+    recipient_pk: &[u8],
+) -> Vec<Opcode> {
+    branch(
+        &[
+            &size_check(20, true)[..],
+            &[op::SHA256],
+            &equals(push_256b_hash(recipient_sha), true)[..],
+            &pay_to_pubkey_hash(recipient_pk)[..],
+        ]
+        .concat(),
+        &[
+            &check_lock_time_verify(lt)[..],
+            &pay_to_pubkey_hash(sender_pk)[..],
+        ]
+        .concat(),
+    )
+}
+
+/// One party has SHA-256 hashlock, other party can spend unconditionally
+pub fn sha256_htlc_with_unconditional(
+    sender_hash: &[u8; 20],
+    recipient_sha: &[u8; 32],
+    recipient_pk: &[u8],
+) -> Vec<Opcode> {
+    branch(
+        &[
+            &[op::SHA256],
+            &equals(push_256b_hash(recipient_sha), true)[..],
+            &pay_to_pubkey_hash(recipient_pk)[..],
+        ]
+        .concat(),
+        &[
+            &[op::_1, op::DROP, op::HASH160],
+            &equals(push_160b_hash(sender_hash), true)[..],
+            &[op::CHECKSIG],
+        ]
+        .concat(),
+    )
+}
+
+/// Two-sided Hash160 HTLC with size checks
+pub fn dual_hash160_htlc_size_check(
+    lt: u32,
+    sender_hash: &[u8; 20],
+    sender_pk: &[u8],
+    recipient_hash: &[u8; 20],
+    recipient_pk: &[u8],
+) -> Vec<Opcode> {
+    let verify = |hash, pk| {
+        [
+            &[op::SIZE],
+            &equals(push_num(20), true)[..],
+            &[op::HASH160],
+            &equals(push_160b_hash(hash), true)[..],
+            &check_sig(pk, false)[..],
+        ]
+        .concat()
+    };
+    branch(
+        &[
+            &check_lock_time_verify(lt)[..],
+            &verify(sender_hash, sender_pk)[..],
+        ]
+        .concat(),
+        &verify(recipient_hash, recipient_pk),
+    )
+}

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -256,7 +256,6 @@ impl<F: StepFn> ZcashScript for StepwiseInterpreter<F> {
 
 #[cfg(test)]
 mod tests {
-    use hex::FromHex;
     use proptest::prelude::{prop, proptest, ProptestConfig};
 
     use super::{stepwise_verify, ComparisonStepEvaluator, Error, StepResults};
@@ -265,34 +264,11 @@ mod tests {
             CallbackTransactionSignatureChecker, DefaultStepEvaluator, VerificationFlags,
         },
         script_error::ScriptError,
-        signature::HashType,
-        testing::{repair_flags, BrokenStepEvaluator, OVERFLOW_SCRIPT_SIZE},
+        testing::{
+            invalid_sighash, missing_sighash, repair_flags, sighash, BrokenStepEvaluator,
+            OVERFLOW_SCRIPT_SIZE, SCRIPT_PUBKEY, SCRIPT_SIG,
+        },
     };
-
-    lazy_static::lazy_static! {
-        pub static ref SCRIPT_PUBKEY: Vec<u8> = <Vec<u8>>::from_hex("a914c117756dcbe144a12a7c33a77cfa81aa5aeeb38187").unwrap();
-        pub static ref SCRIPT_SIG: Vec<u8> = <Vec<u8>>::from_hex("00483045022100d2ab3e6258fe244fa442cfb38f6cef9ac9a18c54e70b2f508e83fa87e20d040502200eead947521de943831d07a350e45af8e36c2166984a8636f0a8811ff03ed09401473044022013e15d865010c257eef133064ef69a780b4bc7ebe6eda367504e806614f940c3022062fdbc8c2d049f91db2042d6c9771de6f1ef0b3b1fea76c1ab5542e44ed29ed8014c69522103b2cc71d23eb30020a4893982a1e2d352da0d20ee657fa02901c432758909ed8f21029d1e9a9354c0d2aee9ffd0f0cea6c39bbf98c4066cf143115ba2279d0ba7dabe2103e32096b63fd57f3308149d238dcbb24d8d28aad95c0e4e74e3e5e6a11b61bcc453ae").expect("Block bytes are in valid hex representation");
-    }
-
-    fn sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
-        hex::decode("e8c7bdac77f6bb1f3aba2eaa1fada551a9c8b3b5ecd1ef86e6e58a5f1aab952c")
-            .unwrap()
-            .as_slice()
-            .first_chunk::<32>()
-            .copied()
-    }
-
-    fn invalid_sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
-        hex::decode("08c7bdac77f6bb1f3aba2eaa1fada551a9c8b3b5ecd1ef86e6e58a5f1aab952c")
-            .unwrap()
-            .as_slice()
-            .first_chunk::<32>()
-            .copied()
-    }
-
-    fn missing_sighash(_script_code: &[u8], _hash_type: &HashType) -> Option<[u8; 32]> {
-        None
-    }
 
     #[test]
     fn it_works() {


### PR DESCRIPTION
This makes it easier to write chunks of Zcash Script in code, with some
higher-level patterns of opcodes to use. The serialization is also
necessary for wallets to produce scripts.

It also removes some of the duplication in the tests, by moving
constants to `crate::testing`.

This depends on #223