### PR TITLE
add: Implement `Display` and derive `Error` traits for error enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,9 +587,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -607,6 +607,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -790,6 +810,7 @@ dependencies = [
  "secp256k1",
  "sha-1",
  "sha2",
+ "thiserror",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ secp256k1 = "0.30"
 sha-1 = "0.10"
 sha2 = "0.10"
 tracing = "0.1"
+thiserror = "2.0"
 
 [build-dependencies]
 # We want zcash-script to be compatible with whatever version of `bindgen` that

--- a/src/script_error.rs
+++ b/src/script_error.rs
@@ -82,3 +82,69 @@ impl From<ScriptNumError> for ScriptError {
         ScriptError::ScriptNumError(value)
     }
 }
+
+impl std::fmt::Display for ScriptError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScriptError::Ok => write!(f, "Ok"),
+            ScriptError::UnknownError => write!(f, "Unknown error"),
+            ScriptError::EvalFalse => write!(f, "Script evaluation failed"),
+            ScriptError::OpReturn => write!(f, "OP_RETURN encountered"),
+
+            // Max sizes
+            ScriptError::ScriptSize => write!(f, "Script size exceeded maximum"),
+            ScriptError::PushSize => write!(f, "Push size exceeded maximum"),
+            ScriptError::OpCount => write!(f, "Operation count exceeded maximum"),
+            ScriptError::StackSize => write!(f, "Stack size exceeded maximum"),
+            ScriptError::SigCount => write!(f, "Signature count exceeded maximum"),
+            ScriptError::PubKeyCount => write!(f, "Public key count exceeded maximum"),
+
+            // Failed verify operations
+            ScriptError::Verify => write!(f, "Verify operation failed"),
+            ScriptError::EqualVerify => write!(f, "Equal verify operation failed"),
+            ScriptError::CheckMultisigVerify => write!(f, "Check multisig verify operation failed"),
+            ScriptError::CheckSigVerify => write!(f, "Check signature verify operation failed"),
+            ScriptError::NumEqualVerify => write!(f, "Number equal verify operation failed"),
+
+            // Logical/Format/Canonical errors
+            ScriptError::BadOpcode => write!(f, "Bad opcode encountered"),
+            ScriptError::DisabledOpcode => write!(f, "Disabled opcode encountered"),
+            ScriptError::InvalidStackOperation => write!(f, "Invalid stack operation"),
+            ScriptError::InvalidAltstackOperation => write!(f, "Invalid altstack operation"),
+            ScriptError::UnbalancedConditional => write!(f, "Unbalanced conditional encountered"),
+
+            // OP_CHECKLOCKTIMEVERIFY
+            ScriptError::NegativeLockTime => write!(f, "Negative lock time encountered"),
+            ScriptError::UnsatisfiedLockTime => write!(f, "Unsatisfied lock time condition"),
+
+            // BIP62
+            ScriptError::SigHashType => write!(f, "Signature hash type error"),
+            ScriptError::SigDER => write!(f, "Signature DER encoding error"),
+            ScriptError::MinimalData => write!(f, "Minimal data requirement not met"),
+            ScriptError::SigPushOnly => write!(f, "Signature push only requirement not met"),
+            ScriptError::SigHighS => write!(f, "Signature S value is too high"),
+            ScriptError::SigNullDummy => write!(f, "Signature null dummy error"),
+            ScriptError::PubKeyType => write!(f, "Public key type error"),
+            ScriptError::CleanStack => write!(f, "Clean stack requirement not met"),
+
+            // softfork safeness
+            ScriptError::DiscourageUpgradableNOPs => {
+                write!(f, "Discouraged upgradable NOPs encountered")
+            }
+
+            ScriptError::ReadError {
+                expected_bytes,
+                available_bytes,
+            } => {
+                write!(
+                    f,
+                    "Read error: expected {expected_bytes} bytes, but only {available_bytes} bytes available",
+                )
+            }
+
+            ScriptError::ScriptNumError(script_num_error) => {
+                write!(f, "Script number error: {}", script_num_error)
+            }
+        }
+    }
+}

--- a/src/script_error.rs
+++ b/src/script_error.rs
@@ -12,127 +12,120 @@ pub enum ScriptNumError {
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Error)]
 #[repr(i32)]
 pub enum ScriptError {
+    #[error("Ok")]
     Ok = 0, // Unused (except in converting the C++ error to Rust)
+
+    #[error("unknown error")]
     UnknownError,
+
+    #[error("script evaluation failed")]
     EvalFalse,
+
+    #[error("OP_RETURN encountered")]
     OpReturn,
 
     // Max sizes
+    #[error("Script size exceeded maximum")]
     ScriptSize,
+
+    #[error("push size exceeded maximum")]
     PushSize,
+
+    #[error("operation count exceeded maximum")]
     OpCount,
+
+    #[error("stack size exceeded maximum")]
     StackSize,
+
+    #[error("signature count exceeded maximum")]
     SigCount,
+
+    #[error("public key count exceeded maximum")]
     PubKeyCount,
 
     // Failed verify operations
+    #[error("verify operation failed")]
     Verify,
+
+    #[error("equal verify operation failed")]
     EqualVerify,
+
+    #[error("check multisig verify operation failed")]
     CheckMultisigVerify,
+
+    #[error("check sig verify operation failed")]
     CheckSigVerify,
+
+    #[error("num equal verfiy operation failed")]
     NumEqualVerify,
 
     // Logical/Format/Canonical errors
+    #[error("bad opcode encountered")]
     BadOpcode,
+
+    #[error("disabled opcode encountered")]
     DisabledOpcode,
+
+    #[error("invalid stack operation encountered")]
     InvalidStackOperation,
+
+    #[error("invalid altstack operation encountered")]
     InvalidAltstackOperation,
+
+    #[error("unbalanced conditional encountered")]
     UnbalancedConditional,
 
     // OP_CHECKLOCKTIMEVERIFY
+    #[error("negative lock time encountered")]
     NegativeLockTime,
+
+    #[error("unsatisfied locktime condition")]
     UnsatisfiedLockTime,
 
     // BIP62
+    #[error("signature hash type error")]
     SigHashType,
+
+    #[error("signature DER encoding error")]
     SigDER,
+
+    #[error("minimal data requirement not met")]
     MinimalData,
+
+    #[error("signature push only requirement not met")]
     SigPushOnly,
+
+    #[error("signature s value is too high")]
     SigHighS,
+
+    #[error("signature null dummy error")]
     SigNullDummy,
+
+    #[error("public key type error")]
     PubKeyType,
+
+    #[error("clean stack requirement not met")]
     CleanStack,
 
     // softfork safeness
+    #[error("discouraged upgradable NOPs encountered")]
     DiscourageUpgradableNOPs,
 
+    #[error(
+        "read error: expected {expected_bytes} bytes, but only {available_bytes} bytes available"
+    )]
     ReadError {
         expected_bytes: usize,
         available_bytes: usize,
     },
 
     /// Corresponds to the `scriptnum_error` exception in C++.
+    #[error("script number error: {0}")]
     ScriptNumError(ScriptNumError),
 }
 
 impl From<ScriptNumError> for ScriptError {
     fn from(value: ScriptNumError) -> Self {
         ScriptError::ScriptNumError(value)
-    }
-}
-
-impl std::fmt::Display for ScriptError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ScriptError::Ok => write!(f, "Ok"),
-            ScriptError::UnknownError => write!(f, "Unknown error"),
-            ScriptError::EvalFalse => write!(f, "Script evaluation failed"),
-            ScriptError::OpReturn => write!(f, "OP_RETURN encountered"),
-
-            // Max sizes
-            ScriptError::ScriptSize => write!(f, "Script size exceeded maximum"),
-            ScriptError::PushSize => write!(f, "Push size exceeded maximum"),
-            ScriptError::OpCount => write!(f, "Operation count exceeded maximum"),
-            ScriptError::StackSize => write!(f, "Stack size exceeded maximum"),
-            ScriptError::SigCount => write!(f, "Signature count exceeded maximum"),
-            ScriptError::PubKeyCount => write!(f, "Public key count exceeded maximum"),
-
-            // Failed verify operations
-            ScriptError::Verify => write!(f, "Verify operation failed"),
-            ScriptError::EqualVerify => write!(f, "Equal verify operation failed"),
-            ScriptError::CheckMultisigVerify => write!(f, "Check multisig verify operation failed"),
-            ScriptError::CheckSigVerify => write!(f, "Check signature verify operation failed"),
-            ScriptError::NumEqualVerify => write!(f, "Number equal verify operation failed"),
-
-            // Logical/Format/Canonical errors
-            ScriptError::BadOpcode => write!(f, "Bad opcode encountered"),
-            ScriptError::DisabledOpcode => write!(f, "Disabled opcode encountered"),
-            ScriptError::InvalidStackOperation => write!(f, "Invalid stack operation"),
-            ScriptError::InvalidAltstackOperation => write!(f, "Invalid altstack operation"),
-            ScriptError::UnbalancedConditional => write!(f, "Unbalanced conditional encountered"),
-
-            // OP_CHECKLOCKTIMEVERIFY
-            ScriptError::NegativeLockTime => write!(f, "Negative lock time encountered"),
-            ScriptError::UnsatisfiedLockTime => write!(f, "Unsatisfied lock time condition"),
-
-            // BIP62
-            ScriptError::SigHashType => write!(f, "Signature hash type error"),
-            ScriptError::SigDER => write!(f, "Signature DER encoding error"),
-            ScriptError::MinimalData => write!(f, "Minimal data requirement not met"),
-            ScriptError::SigPushOnly => write!(f, "Signature push only requirement not met"),
-            ScriptError::SigHighS => write!(f, "Signature S value is too high"),
-            ScriptError::SigNullDummy => write!(f, "Signature null dummy error"),
-            ScriptError::PubKeyType => write!(f, "Public key type error"),
-            ScriptError::CleanStack => write!(f, "Clean stack requirement not met"),
-
-            // softfork safeness
-            ScriptError::DiscourageUpgradableNOPs => {
-                write!(f, "Discouraged upgradable NOPs encountered")
-            }
-
-            ScriptError::ReadError {
-                expected_bytes,
-                available_bytes,
-            } => {
-                write!(
-                    f,
-                    "Read error: expected {expected_bytes} bytes, but only {available_bytes} bytes available",
-                )
-            }
-
-            ScriptError::ScriptNumError(script_num_error) => {
-                write!(f, "Script number error: {}", script_num_error)
-            }
-        }
     }
 }

--- a/src/script_error.rs
+++ b/src/script_error.rs
@@ -23,7 +23,7 @@ impl std::fmt::Display for ScriptNumError {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Error)]
 #[repr(i32)]
 pub enum ScriptError {
     Ok = 0, // Unused (except in converting the C++ error to Rust)

--- a/src/script_error.rs
+++ b/src/script_error.rs
@@ -2,25 +2,11 @@ use thiserror::Error;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Error)]
 pub enum ScriptNumError {
+    #[error("non-minimal encoding of script number")]
     NonMinimalEncoding,
-    Overflow { max_num_size: usize, actual: usize },
-}
 
-impl std::fmt::Display for ScriptNumError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ScriptNumError::NonMinimalEncoding => {
-                write!(f, "Non-minimal encoding of script number")
-            }
-            ScriptNumError::Overflow {
-                max_num_size,
-                actual,
-            } => write!(
-                f,
-                "Script number overflow: max: {max_num_size}, actual: {actual}",
-            ),
-        }
-    }
+    #[error("script number overflow: max: {max_num_size}, actual: {actual}")]
+    Overflow { max_num_size: usize, actual: usize },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Error)]

--- a/src/script_error.rs
+++ b/src/script_error.rs
@@ -4,6 +4,23 @@ pub enum ScriptNumError {
     Overflow { max_num_size: usize, actual: usize },
 }
 
+impl std::fmt::Display for ScriptNumError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScriptNumError::NonMinimalEncoding => {
+                write!(f, "Non-minimal encoding of script number")
+            }
+            ScriptNumError::Overflow {
+                max_num_size,
+                actual,
+            } => write!(
+                f,
+                "Script number overflow: max: {max_num_size}, actual: {actual}",
+            ),
+        }
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum ScriptError {

--- a/src/script_error.rs
+++ b/src/script_error.rs
@@ -1,4 +1,6 @@
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+use thiserror::Error;
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Error)]
 pub enum ScriptNumError {
     NonMinimalEncoding,
     Overflow { max_num_size: usize, actual: usize },

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -22,6 +22,17 @@ pub enum Error {
     Unknown(i64),
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Ok(e) => write!(f, "{e}"),
+            Error::VerifyScript => write!(f, "script verification failed"),
+            Error::InvalidScriptSize(e) => write!(f, "invalid script size: {e}"),
+            Error::Unknown(code) => write!(f, "unknown error code: {code}",),
+        }
+    }
+}
+
 /// The external API of zcash_script. This is defined to make it possible to compare the C++ and
 /// Rust implementations.
 pub trait ZcashScript {

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -12,27 +12,23 @@ use super::script_error::*;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Error)]
 pub enum Error {
     /// Any failure that results in the script being invalid.
+    #[error("{0}")]
     Ok(ScriptError),
+
     /// An exception was caught.
+    #[error("script verification failed")]
     VerifyScript,
+
     /// The script size can’t fit in a `u32`, as required by the C++ code.
+    #[error("invalid script size: {0}")]
     InvalidScriptSize(TryFromIntError),
+
     /// Some other failure value recovered from C++.
     ///
     /// __NB__: Linux uses `u32` for the underlying C++ enum while Windows uses `i32`, so `i64` can
     ///         hold either.
+    #[error("unknown error code: {0}")]
     Unknown(i64),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Ok(e) => write!(f, "{e}"),
-            Error::VerifyScript => write!(f, "script verification failed"),
-            Error::InvalidScriptSize(e) => write!(f, "invalid script size: {e}"),
-            Error::Unknown(code) => write!(f, "unknown error code: {code}",),
-        }
-    }
 }
 
 /// The external API of zcash_script. This is defined to make it possible to compare the C++ and

--- a/src/zcash_script.rs
+++ b/src/zcash_script.rs
@@ -1,5 +1,7 @@
 use std::num::TryFromIntError;
 
+use thiserror::Error;
+
 use super::interpreter::*;
 use super::script::*;
 use super::script_error::*;
@@ -7,7 +9,7 @@ use super::script_error::*;
 /// This maps to `zcash_script_error_t`, but most of those cases aren’t used any more. This only
 /// replicates the still-used cases, and then an `Unknown` bucket for anything else that might
 /// happen.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Error)]
 pub enum Error {
     /// Any failure that results in the script being invalid.
     Ok(ScriptError),


### PR DESCRIPTION
## Motivation

I needed the [`Error`](https://github.com/zcashfoundation/zcash_script/blob/87a3f4b7b23bd232128bd65cf10ac1a43e90a543/src/zcash_script.rs#L13) enum to implement the [`Error`](https://doc.rust-lang.org/std/error/trait.Error.html) trait so I could use it in Zebra conveniently.

## Solution

- Implement `Display` and derive [`Error`](https://doc.rust-lang.org/std/error/trait.Error.html) for all relevant types.