### PR TITLE
ci: remove cargo dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: cargo
-    directory: '/'
-    # Update only the lockfile. We shouldn't update Cargo.toml unless it's for
-    # a security issue, or if we need a new feature of the dependency.
-    versioning-strategy: lockfile-only
-    schedule:
-      interval: daily
-      timezone: America/New_York
-    open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: '/'
     schedule:


### PR DESCRIPTION
Dependabot for Rust it not generally useful for this repo. We should update dependencies manually if required before each release.