### PR TITLE
change: Make script module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod external;
 pub mod interpreter;
 pub mod op;
 pub mod pv;
-mod script;
+pub mod script;
 pub mod script_error;
 pub mod signature;
 mod zcash_script;


### PR DESCRIPTION
## Motivation

- https://github.com/zcash/librustzcash/pull/1893 uses [zcash_script::script::serialize_num](https://github.com/ZcashFoundation/zcash_script/blob/master/src/script.rs?rgh-link-date=2025-08-20T19%3A18%3A06Z#L407) here: https://github.com/zcash/librustzcash/blob/5ebd90259d90184dc8159cd602e572ec780d7ea4/zcash_transparent/src/bundle.rs#L255.