### PR TITLE
Fix the fuzzer

### DIFF
--- a/fuzz/fuzz_targets/compare.rs
+++ b/fuzz/fuzz_targets/compare.rs
@@ -19,7 +19,7 @@ fuzz_target!(|tup: (u32, bool, &[u8], &[u8], u32)| {
     // `fuzz_target!` doesn’t support pattern matching in the parameter list.
     let (lock_time, is_final, pub_key, sig, flag_bits) = tup;
     let flags = testing::repair_flags(interpreter::Flags::from_bits_truncate(flag_bits));
-    let script = script::Raw::from_raw_parts(sig, pub_key);
+    let script = script::Raw::from_raw_parts(sig.to_vec(), pub_key.to_vec());
     let ret = check_verify_callback(
         &CxxInterpreter {
             sighash: &missing_sighash,


### PR DESCRIPTION
`script::Raw` had its type change, but the fuzzer didn’t get updated at the time.