### PR TITLE
Release `zcash_script 0.4.0`, `libzcash_script 0.1.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zcash_script"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "bitflags",
  "bounded-vec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "libzcash_script"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ repository = "https://github.com/ZcashFoundation/zcash_script"
 [workspace.dependencies]
 # Intra-workspace dependencies
 libzcash_script = { version = "0.0.0", path = "libzcash_script" }
-zcash_script = { version = "0.3.2", path = "zcash_script" }
+zcash_script = { version = "0.4", path = "zcash_script" }
 
 # C++ build dependencies
 # See Note [explicit >= version requirements]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ repository = "https://github.com/ZcashFoundation/zcash_script"
 
 [workspace.dependencies]
 # Intra-workspace dependencies
-libzcash_script = { version = "0.0.0", path = "libzcash_script" }
+libzcash_script = { version = "0.1", path = "libzcash_script" }
 zcash_script = { version = "0.4", path = "zcash_script" }
 
 # C++ build dependencies

--- a/libzcash_script/CHANGELOG.md
+++ b/libzcash_script/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
-### Added
-- This was extracted from zcash_script 0.3.2.
+
+## [0.1.0] - 2025-09-25
+
+This crate was extracted from `zcash_script 0.3.2` and then modified to align with
+`zcash_script 0.4.0`.
 
 <!-- next-url -->
-[Unreleased]: https://github.com/ZcashFoundation/zcash_script
+[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/libzcash_script-v0.1.0...HEAD
+[0.1.0]: https://github.com/ZcashFoundation/zcash_script/releases/tag/libzcash_script-v0.1.0

--- a/libzcash_script/Cargo.toml
+++ b/libzcash_script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzcash_script"
-version = "0.0.0"
+version = "0.1.0"
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/zcash_script/CHANGELOG.md
+++ b/zcash_script/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [0.4.0] - 2025-09-25
+
 This is a significant change, with a new Rust API that isn’t made to be swappable with the C++ API. The previous `ZcashScript`-based API is in the new `libzcash_script` crate.
 
 ### Removed
@@ -177,7 +179,8 @@ This is a significant change, with a new Rust API that isn’t made to be swappa
 - Updated `bindgen` to a non yanked version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/ZcashFoundation/zcash_script/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/ZcashFoundation/zcash_script/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/ZcashFoundation/zcash_script/compare/v0.2.0...v0.3.1
 [0.2.0]: https://github.com/ZcashFoundation/zcash_script/compare/v0.1.16...v0.2.0

--- a/zcash_script/Cargo.toml
+++ b/zcash_script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_script"
-version = "0.3.2"
+version = "0.4.0"
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/zcash_script/src/lib.rs
+++ b/zcash_script/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
-#![doc(html_root_url = "https://docs.rs/zcash_script/0.3.2")]
+#![doc(html_root_url = "https://docs.rs/zcash_script/0.4.0")]
 #![allow(clippy::unit_arg)]
 #![allow(non_snake_case)]
 #![allow(unsafe_code)]


### PR DESCRIPTION
Given that our eventual plan is to end support for `libzcash_script`, my proposal is that we keep tagging the `zcash_script` release commits with the regular tags (so this would be `v0.4.0`), while the `libzcash_script` release tags are prefixed (so this would be `libzcash_script-v0.1.0`).