### PR TITLE
fix: add `static_cast`s to `CAmount` for cross-compilation

### DIFF
--- a/libzcash_script/depend/zcash/src/amount.cpp
+++ b/libzcash_script/depend/zcash/src/amount.cpp
@@ -15,7 +15,7 @@ const std::string MINOR_CURRENCY_UNIT = "zatoshis";
 CFeeRate::CFeeRate(const CAmount& nFeePaid, size_t nSize)
 {
     if (nSize > 0) {
-        nSatoshisPerK = std::min(nFeePaid*1000/nSize, (uint64_t)INT64_MAX / MAX_BLOCK_SIZE);
+        nSatoshisPerK = std::min<CAmount>(nFeePaid * 1000 / nSize, static_cast<CAmount>(INT64_MAX) / static_cast<CAmount>(MAX_BLOCK_SIZE));
     } else {
         nSatoshisPerK = 0;
     }
@@ -28,7 +28,7 @@ CAmount CFeeRate::GetFeeForRelay(size_t nSize) const
 
 CAmount CFeeRate::GetFee(size_t nSize) const
 {
-    CAmount nFee = nSatoshisPerK*nSize / 1000;
+    CAmount nFee = nSatoshisPerK * nSize / 1000;
 
     if (nFee == 0 && nSatoshisPerK > 0)
         nFee = nSatoshisPerK;


### PR DESCRIPTION
Fixes #299.