### PR TITLE
make sig_op_count() match zcashd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zcash_script"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "bip32",
  "bitflags",

--- a/zcash_script/CHANGELOG.md
+++ b/zcash_script/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [0.4.5] - 2026-05-29
+
+### Changed
+
+- Changed `sig_op_count()` to match zcashd
+
 ## [0.4.4] - 2026-04-17
 
 ## Added
@@ -220,7 +226,8 @@ This is a significant change, with a new Rust API that isn’t made to be swappa
 - Updated `bindgen` to a non yanked version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/zcash_script-v0.4.4...HEAD
+[Unreleased]: https://github.com/ZcashFoundation/zcash_script/compare/zcash_script-v0.4.5...HEAD
+[0.4.5]: https://github.com/ZcashFoundation/zcash_script/compare/zcash_script-v0.4.4...zcash_script-v0.4.5
 [0.4.4]: https://github.com/ZcashFoundation/zcash_script/compare/zcash_script-v0.4.2...zcash_script-v0.4.4
 [0.4.3]: https://github.com/ZcashFoundation/zcash_script/compare/zcash_script-v0.4.2...zcash_script-v0.4.3
 [0.4.2]: https://github.com/ZcashFoundation/zcash_script/compare/zcash_script-v0.4.1...zcash_script-v0.4.2

--- a/zcash_script/Cargo.toml
+++ b/zcash_script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash_script"
-version = "0.4.4"
+version = "0.4.5"
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/zcash_script/src/lib.rs
+++ b/zcash_script/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
-#![doc(html_root_url = "https://docs.rs/zcash_script/0.4.4")]
+#![doc(html_root_url = "https://docs.rs/zcash_script/0.4.5")]
 #![allow(clippy::unit_arg)]
 #![allow(non_snake_case)]
 #![allow(unsafe_code)]

--- a/zcash_script/src/script/iter.rs
+++ b/zcash_script/src/script/iter.rs
@@ -103,18 +103,68 @@ pub fn eval<T: Into<opcode::PossiblyBad> + opcode::Evaluable + Clone>(
 /// Pre-version-0.6, Bitcoin always counted CHECKMULTISIGs as 20 sigops. With pay-to-script-hash,
 /// that changed: CHECKMULTISIGs serialized in script_sigs are counted more accurately, assuming
 /// they are of the form ... OP_N CHECKMULTISIG ...
+///
+/// This mirrors zcashd's `CScript::GetSigOpCount`, which walks the script with `GetOp` and stops
+/// only when `GetOp` fails (a push that runs past the end of the script). Bytes this crate
+/// classifies as `Disabled` (OP_CAT, ..., and OP_CODESEPARATOR) are read by zcashd's `GetOp` like
+/// any other opcode: they perform no signature operation, so they add 0 and counting continues.
+/// They are rejected only when a script is *evaluated*, never while counting. Treating one as a
+/// hard stop here would under-count sigops relative to zcashd and open a consensus split, so we
+/// skip past it.
 pub fn sig_op_count<T: Into<opcode::PossiblyBad> + opcode::Evaluable>(
-    mut iter: impl Iterator<Item = Result<T, opcode::Error>>,
+    iter: impl Iterator<Item = Result<T, opcode::Error>>,
     accurate: bool,
 ) -> u32 {
-    iter.try_fold((0, None), |(sum, last_opcode), opcode| {
-        opcode.map_err(|_| sum).map(|op| {
-            (
-                sum + op.sig_op_count(last_opcode),
-                accurate.then(|| op.into()),
-            )
-        })
-    })
-    .map(|(sum, _)| sum)
-    .unwrap_or_else(|x| x)
+    let mut n: u32 = 0;
+    let mut last_opcode: Option<opcode::PossiblyBad> = None;
+    for item in iter {
+        match item {
+            Ok(op) => {
+                n += op.sig_op_count(last_opcode.take());
+                last_opcode = accurate.then(|| op.into());
+            }
+            // A disabled opcode is a valid byte to zcashd's `GetOp`: 0 sigops, keep going, and
+            // reset `last_opcode` so a following CHECKMULTISIG is charged the full 20 (zcashd sets
+            // `lastOpcode` to the disabled opcode, which is never OP_1..=OP_16).
+            Err(opcode::Error::Disabled(_)) => last_opcode = None,
+            // `Read` is a truncated push (zcashd's `GetOp` returns false -> stop). `PushSize` is a
+            // push declaring more than LargeValue::MAX_SIZE (520) bytes, which cannot occur inside
+            // a spendable (<= 520-byte) redeem script, so a hard stop cannot diverge from zcashd on
+            // any consensus-valid input.
+            Err(opcode::Error::Read { .. } | opcode::Error::PushSize(_)) => break,
+        }
+    }
+    n
+}
+
+#[cfg(test)]
+mod sig_op_count_tests {
+    use alloc::vec::Vec;
+
+    use crate::script::Code;
+
+    /// `sig_op_count` must match zcashd's `CScript::GetSigOpCount` even when the script contains
+    /// opcodes this crate buckets under `Disabled` -- in particular OP_CODESEPARATOR (0xab), which
+    /// is a normal, valid opcode in zcashd and must not stop the count.
+    #[test]
+    fn does_not_short_circuit_on_disabled_opcodes() {
+        // OP_1 OP_CHECKMULTISIG: accurate counts the OP_N prefix (1); legacy counts 20.
+        assert_eq!(Code(Vec::from([0x51u8, 0xae])).sig_op_count(true), 1);
+        assert_eq!(Code(Vec::from([0x51u8, 0xae])).sig_op_count(false), 20);
+
+        // OP_CODESEPARATOR (0xab) then OP_CHECKSIG: zcashd keeps counting -> 1.
+        assert_eq!(Code(Vec::from([0xabu8, 0xac])).sig_op_count(true), 1);
+
+        // OP_CAT (0x7e, truly disabled) then OP_CHECKSIG: zcashd still keeps counting -> 1.
+        assert_eq!(Code(Vec::from([0x7eu8, 0xac])).sig_op_count(true), 1);
+
+        // OP_CODESEPARATOR before 50 x OP_CHECKMULTISIG: each charged 20 (no OP_N prefix),
+        // matching zcashd's GetSigOpCount(true) == 1000.
+        let mut s = Vec::from([0xabu8]);
+        s.extend([0xaeu8; 50]);
+        assert_eq!(Code(s).sig_op_count(true), 1000);
+
+        // A truncated push stops the count, like zcashd's GetOp returning false.
+        assert_eq!(Code(Vec::from([0xacu8, 0x05, 0x01])).sig_op_count(true), 1);
+    }
 }


### PR DESCRIPTION
Fixes sig op count in the Rust path to match zcashd behaviour