### PR TITLE
fix(libzcash_script): don't panic when bindgen can't parse rust-version

### DIFF
--- a/libzcash_script/build.rs
+++ b/libzcash_script/build.rs
@@ -36,11 +36,7 @@ fn bindgen_headers() -> Result<()> {
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // This can be removed once rust-lang/rust-bindgen#3049 is fixed.
-        .rust_target(
-            env!("CARGO_PKG_RUST_VERSION")
-                .parse()
-                .expect("Cargo ‘rust-version’ is a valid value"),
-        )
+        .rust_target(env!("CARGO_PKG_RUST_VERSION").parse().unwrap_or_default())
         .use_core()
         // Finish the builder and generate the bindings.
         .generate()


### PR DESCRIPTION
`libzcash_script`'s `build.rs` parses `CARGO_PKG_RUST_VERSION` and `.expect()`s the result. When `bindgen` doesn't recognize the value as a known `RustTarget`, the build panics instead of falling back. This fix swaps the `.expect()` for `unwrap_or_default()` so the build proceeds with bindgen's default target.

Requested by @nullcopy.